### PR TITLE
Fetch SDL2 automatically when missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,17 @@ add_executable(minirt
 )
 
 find_package(Threads REQUIRED)
-find_package(SDL2 REQUIRED CONFIG)
+find_package(SDL2 QUIET CONFIG)
+if(NOT SDL2_FOUND)
+    message(STATUS "SDL2 not found, fetching with FetchContent")
+    include(FetchContent)
+    FetchContent_Declare(
+        SDL2
+        GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+        GIT_TAG release-2.30.3
+    )
+    set(SDL2_DISABLE_INSTALL ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(SDL2)
+endif()
 target_include_directories(minirt PRIVATE include)
 target_link_libraries(minirt PRIVATE Threads::Threads SDL2::SDL2)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A minimal ray tracer skeleton implemented in C++.
 ## Prerequisites
 - CMake >= 3.16
 - C++17 compatible compiler (e.g., GCC, Clang, MSVC)
-- SDL2 development libraries
+- SDL2 development libraries (CMake fetches SDL2 automatically if missing)
 - Make or another build tool
 
 ## Build


### PR DESCRIPTION
## Summary
- Use CMake FetchContent to download and build SDL2 when not found locally.
- Document automatic SDL2 fetching in prerequisites.

## Testing
- `cmake -S . -B build` *(terminated after confirming SDL2 fetch due to long configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68af27d4a114832f86386589276a8078