### PR TITLE
Recalculate beams when scene objects change

### DIFF
--- a/include/rt/Renderer.hpp
+++ b/include/rt/Renderer.hpp
@@ -18,14 +18,14 @@ struct RenderSettings
 class Renderer
 {
 public:
-  Renderer(const Scene &s, Camera &c);
+  Renderer(Scene &s, Camera &c);
   void render_ppm(const std::string &path, const std::vector<Material> &mats,
                   const RenderSettings &rset);
   void render_window(const std::vector<Material> &mats,
                      const RenderSettings &rset);
 
 private:
-  const Scene &scene;
+  Scene &scene;
   Camera &cam;
 };
 

--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -3,6 +3,7 @@
 #include "BVH.hpp"
 #include "Hittable.hpp"
 #include "light.hpp"
+#include "material.hpp"
 #include <memory>
 #include <vector>
 
@@ -17,6 +18,7 @@ struct Scene
 
   void build_bvh();
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
+  void update_beams(const std::vector<Material> &materials);
 };
 
 } // namespace rt

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -101,11 +101,6 @@ inline bool parse_rgba(std::string_view sv, rt::Vec3 &out, double &a)
 }
 inline double alpha_to_unit(double a) { return a / 255.0; }
 
-inline rt::Vec3 reflect(const rt::Vec3 &v, const rt::Vec3 &n)
-{
-  return v - n * (2.0 * rt::Vec3::dot(v, n));
-}
-
 } // namespace
 
 namespace rt
@@ -279,47 +274,8 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
     // TODO: textures...
   }
 
-  // Trim beams and add reflections
-  for (size_t i = 0; i < outScene.objects.size(); ++i)
-  {
-    auto obj = outScene.objects[i];
-    if (!obj->is_beam())
-      continue;
-    Beam *bm = static_cast<Beam *>(obj.get());
-    Ray forward(bm->path.orig, bm->path.dir);
-    HitRecord tmp, hit_rec;
-    bool hit_any = false;
-    double closest = bm->length;
-    for (auto &other : outScene.objects)
-    {
-      if (other.get() == bm)
-        continue;
-      if (other->hit(forward, 1e-4, closest, tmp))
-      {
-        closest = tmp.t;
-        hit_rec = tmp;
-        hit_any = true;
-      }
-    }
-    if (hit_any)
-    {
-      bm->length = closest;
-      if (materials[hit_rec.material_id].mirror)
-      {
-        double new_start = bm->start + closest;
-        double new_len = bm->total_length - new_start;
-        if (new_len > 1e-4)
-        {
-          Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
-          Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
-          auto new_bm = std::make_shared<Beam>(refl_orig, refl_dir, bm->radius,
-                                               new_len, oid++, bm->material_id,
-                                               new_start, bm->total_length);
-          outScene.objects.push_back(new_bm);
-        }
-      }
-    }
-  }
+  // Trim beams and add reflections based on current scene geometry
+  outScene.update_beams(materials);
 
   outCamera =
       Camera(cam_pos, cam_pos + cam_dir, fov, double(width) / double(height));

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -85,7 +85,7 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
   return sum;
 }
 
-Renderer::Renderer(const Scene &s, Camera &c) : scene(s), cam(c) {}
+Renderer::Renderer(Scene &s, Camera &c) : scene(s), cam(c) {}
 
 void Renderer::render_ppm(const std::string &path,
                           const std::vector<Material> &mats,
@@ -99,6 +99,8 @@ void Renderer::render_ppm(const std::string &path,
                            ? (int)std::thread::hardware_concurrency()
                            : 8);
 
+  scene.update_beams(mats);
+  scene.build_bvh();
   std::vector<Vec3> framebuffer(W * H);
   std::atomic<int> next_row{0};
 
@@ -256,6 +258,9 @@ void Renderer::render_window(const std::vector<Material> &mats,
       if (state[SDL_SCANCODE_D])
         cam.move(cam.right * speed);
     }
+
+    scene.update_beams(mats);
+    scene.build_bvh();
 
     std::atomic<int> next_row{0};
     auto worker = [&]()

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,4 +1,11 @@
 #include "rt/Scene.hpp"
+#include "rt/Beam.hpp"
+#include "rt/Cone.hpp"
+#include "rt/Cylinder.hpp"
+#include "rt/Plane.hpp"
+#include "rt/Sphere.hpp"
+#include <algorithm>
+#include <functional>
 
 namespace rt
 {
@@ -32,6 +39,79 @@ bool Scene::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
     }
   }
   return hit_any;
+}
+
+void Scene::update_beams(const std::vector<Material> &materials)
+{
+  // collect non-beam objects and beam sources
+  std::vector<HittablePtr> static_objs;
+  std::vector<std::shared_ptr<Beam>> sources;
+  for (auto &obj : objects)
+  {
+    if (obj->is_beam())
+    {
+      Beam *bm = static_cast<Beam *>(obj.get());
+      if (bm->start < 1e-6)
+      {
+        bm->length = bm->total_length;
+        sources.push_back(std::static_pointer_cast<Beam>(obj));
+      }
+    }
+    else
+    {
+      static_objs.push_back(obj);
+    }
+  }
+
+  objects = static_objs;
+
+  auto reflect = [](const Vec3 &v, const Vec3 &n) {
+    return v - n * (2.0 * Vec3::dot(v, n));
+  };
+
+  static int next_oid = 100000;
+
+  std::function<void(const Vec3 &, const Vec3 &, double, double, double, int)>
+      shoot = [&](const Vec3 &orig, const Vec3 &dir, double radius,
+                  double start, double total, int mat_id) {
+        Ray forward(orig, dir.normalized());
+        HitRecord tmp, hit_rec;
+        bool hit_any = false;
+        double remaining = total - start;
+        double closest = remaining;
+        for (auto &other : static_objs)
+        {
+          if (other->hit(forward, 1e-4, closest, tmp))
+          {
+            closest = tmp.t;
+            hit_rec = tmp;
+            hit_any = true;
+          }
+        }
+
+        auto bm = std::make_shared<Beam>(orig, dir, radius,
+                                         hit_any ? closest : remaining,
+                                         next_oid++, mat_id, start, total);
+        objects.push_back(bm);
+
+        if (hit_any && materials[hit_rec.material_id].mirror)
+        {
+          double new_start = start + closest;
+          double new_len = total - new_start;
+          if (new_len > 1e-4)
+          {
+            Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
+            Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
+            shoot(refl_orig, refl_dir, radius, new_start, total, mat_id);
+          }
+        }
+      };
+
+  for (auto &src : sources)
+  {
+    shoot(src->path.orig, src->path.dir, src->radius, 0.0, src->total_length,
+          src->material_id);
+  }
 }
 
 } // namespace rt


### PR DESCRIPTION
## Summary
- add `Scene::update_beams` to rebuild beams and reflections based on current scene geometry
- allow renderer to mutate the scene and update beams each frame
- recompute beams during parsing and before rendering

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b0799749c0832f9ac900c7c122c098