### PR TITLE
Recompute beams dynamically when scene changes

### DIFF
--- a/include/rt/Renderer.hpp
+++ b/include/rt/Renderer.hpp
@@ -18,14 +18,14 @@ struct RenderSettings
 class Renderer
 {
 public:
-  Renderer(const Scene &s, Camera &c);
+  Renderer(Scene &s, Camera &c);
   void render_ppm(const std::string &path, const std::vector<Material> &mats,
                   const RenderSettings &rset);
   void render_window(const std::vector<Material> &mats,
                      const RenderSettings &rset);
 
 private:
-  const Scene &scene;
+  Scene &scene;
   Camera &cam;
 };
 

--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -14,8 +14,10 @@ struct Scene
   std::vector<PointLight> lights;
   Ambient ambient{Vec3(1, 1, 1), 0.0};
   std::shared_ptr<Hittable> accel;
+  int next_object_id = 0;
 
   void build_bvh();
+  void update_beams();
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
 };
 

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -323,6 +323,7 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
 
   outCamera =
       Camera(cam_pos, cam_pos + cam_dir, fov, double(width) / double(height));
+  outScene.next_object_id = oid;
   return true;
 }
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -85,7 +85,7 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
   return sum;
 }
 
-Renderer::Renderer(const Scene &s, Camera &c) : scene(s), cam(c) {}
+Renderer::Renderer(Scene &s, Camera &c) : scene(s), cam(c) {}
 
 void Renderer::render_ppm(const std::string &path,
                           const std::vector<Material> &mats,
@@ -101,6 +101,8 @@ void Renderer::render_ppm(const std::string &path,
 
   std::vector<Vec3> framebuffer(W * H);
   std::atomic<int> next_row{0};
+
+  scene.update_beams();
 
   auto worker = [&]()
   {
@@ -256,6 +258,8 @@ void Renderer::render_window(const std::vector<Material> &mats,
       if (state[SDL_SCANCODE_D])
         cam.move(cam.right * speed);
     }
+
+    scene.update_beams();
 
     std::atomic<int> next_row{0};
     auto worker = [&]()

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,4 +1,7 @@
 #include "rt/Scene.hpp"
+#include "rt/Beam.hpp"
+#include "rt/Parser.hpp"
+#include <algorithm>
 
 namespace rt
 {
@@ -11,6 +14,83 @@ void Scene::build_bvh()
   }
   std::vector<HittablePtr> objs = objects;
   accel = std::make_shared<BVHNode>(objs, 0, objs.size());
+}
+
+static inline Vec3 reflect(const Vec3 &v, const Vec3 &n)
+{
+  return v - n * (2.0 * Vec3::dot(v, n));
+}
+
+void Scene::update_beams()
+{
+  // Remove reflection segments
+  objects.erase(std::remove_if(objects.begin(), objects.end(), [](const HittablePtr &o) {
+                    if (o->is_beam())
+                    {
+                      Beam *b = static_cast<Beam *>(o.get());
+                      return b->start > 0.0;
+                    }
+                    return false;
+                  }),
+                  objects.end());
+
+  // Reset lengths of root beams
+  for (auto &o : objects)
+  {
+    if (o->is_beam())
+    {
+      Beam *b = static_cast<Beam *>(o.get());
+      b->length = b->total_length;
+    }
+  }
+
+  int oid = next_object_id;
+  const auto &materials = Parser::get_materials();
+
+  size_t base_size = objects.size();
+  for (size_t i = 0; i < base_size; ++i)
+  {
+    if (!objects[i]->is_beam())
+      continue;
+    Beam *bm = static_cast<Beam *>(objects[i].get());
+    Ray forward(bm->path.orig, bm->path.dir);
+    HitRecord tmp, hit_rec;
+    bool hit_any = false;
+    double closest = bm->length;
+    for (auto &other : objects)
+    {
+      if (other.get() == bm)
+        continue;
+      if (other->hit(forward, 1e-4, closest, tmp))
+      {
+        closest = tmp.t;
+        hit_rec = tmp;
+        hit_any = true;
+      }
+    }
+    if (hit_any)
+    {
+      bm->length = closest;
+      if (materials[hit_rec.material_id].mirror)
+      {
+        double new_start = bm->start + closest;
+        double new_len = bm->total_length - new_start;
+        if (new_len > 1e-4)
+        {
+          Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
+          Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
+          auto new_bm = std::make_shared<Beam>(refl_orig, refl_dir, bm->radius,
+                                               new_len, oid++, bm->material_id,
+                                               new_start, bm->total_length);
+          objects.push_back(new_bm);
+        }
+      }
+    }
+  }
+
+  next_object_id = oid;
+
+  build_bvh();
 }
 
 bool Scene::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const


### PR DESCRIPTION
## Summary
- Allow `Renderer` to modify the scene and trigger beam updates
- Add `Scene::update_beams` to rebuild beam paths based on current objects
- Track next object id so reflected beams remain unique

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b0799749c0832f9ac900c7c122c098