### PR TITLE
Ensure SDL2 dependency is fetched automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,18 @@ file(GLOB SRC_FILES CONFIGURE_DEPENDS src/*.cpp)
 add_executable(minirt ${SRC_FILES})
 
 find_package(Threads REQUIRED)
-find_package(SDL2 REQUIRED CONFIG)
+
+# Try to locate an existing SDL2 installation.  If not found, fetch and build
+# SDL2 from source so that users without system packages can still build the
+# project, as advertised in the README.
+find_package(SDL2 CONFIG QUIET)
+if(NOT SDL2_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(SDL2
+        URL https://github.com/libsdl-org/SDL/releases/download/release-2.30.2/SDL2-2.30.2.zip
+    )
+    FetchContent_MakeAvailable(SDL2)
+endif()
+
 target_include_directories(minirt PRIVATE include)
 target_link_libraries(minirt PRIVATE Threads::Threads SDL2::SDL2)


### PR DESCRIPTION
## Summary
- Automatically download and build SDL2 with FetchContent when not found
- Link the project against the fetched SDL2 library

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b151f601d0832f90ec2d658c21483f