### PR TITLE
Update beams when scene objects move

### DIFF
--- a/include/rt/Beam.hpp
+++ b/include/rt/Beam.hpp
@@ -11,9 +11,6 @@ struct Beam : public Hittable
   double length;
   double start;
   double total_length;
-  int object_id;
-  int material_id;
-
   Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
        int oid, int mid, double start = 0.0, double total = -1.0);
 

--- a/include/rt/Cone.hpp
+++ b/include/rt/Cone.hpp
@@ -10,9 +10,6 @@ struct Cone : public Hittable
   Vec3 axis;
   double radius;
   double height;
-  int object_id;
-  int material_id;
-
   Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid);
 
   bool hit(const Ray &r, double tmin, double tmax,

--- a/include/rt/Cylinder.hpp
+++ b/include/rt/Cylinder.hpp
@@ -10,9 +10,6 @@ struct Cylinder : public Hittable
   Vec3 axis;
   double radius;
   double height;
-  int object_id;
-  int material_id;
-
   Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h, int oid,
            int mid);
 

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -25,6 +25,8 @@ struct HitRecord
 struct Hittable
 {
   bool movable = false;
+  int object_id = 0;
+  int material_id = 0;
   virtual ~Hittable() = default;
   virtual bool hit(const Ray &r, double tmin, double tmax,
                    HitRecord &rec) const = 0;

--- a/include/rt/Plane.hpp
+++ b/include/rt/Plane.hpp
@@ -8,9 +8,6 @@ struct Plane : public Hittable
 {
   Vec3 point;
   Vec3 normal;
-  int object_id;
-  int material_id;
-
   Plane(const Vec3 &p, const Vec3 &n, int oid, int mid);
 
   bool hit(const Ray &r, double tmin, double tmax,

--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -3,6 +3,7 @@
 #include "BVH.hpp"
 #include "Hittable.hpp"
 #include "light.hpp"
+#include "material.hpp"
 #include <memory>
 #include <vector>
 
@@ -15,6 +16,7 @@ struct Scene
   Ambient ambient{Vec3(1, 1, 1), 0.0};
   std::shared_ptr<Hittable> accel;
 
+  void update_beams(const std::vector<Material> &mats);
   void build_bvh();
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
 };

--- a/include/rt/Sphere.hpp
+++ b/include/rt/Sphere.hpp
@@ -9,9 +9,6 @@ struct Sphere : public Hittable
 {
   Vec3 center;
   double radius;
-  int object_id;
-  int material_id;
-
   Sphere(const Vec3 &c, double r, int oid, int mid);
 
   bool hit(const Ray &r, double tmin, double tmax,

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -7,8 +7,10 @@ namespace rt
 Beam::Beam(const Vec3 &origin, const Vec3 &dir, double r, double len, int oid,
            int mid, double s, double total)
     : path(origin, dir.normalized()), radius(r), length(len), start(s),
-      total_length(total < 0 ? len : total), object_id(oid), material_id(mid)
+      total_length(total < 0 ? len : total)
 {
+  object_id = oid;
+  material_id = mid;
 }
 
 bool Beam::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const

--- a/src/Cone.cpp
+++ b/src/Cone.cpp
@@ -4,9 +4,10 @@
 namespace rt
 {
 Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid)
-    : center(c), axis(ax.normalized()), radius(r), height(h), object_id(oid),
-      material_id(mid)
+    : center(c), axis(ax.normalized()), radius(r), height(h)
 {
+  object_id = oid;
+  material_id = mid;
 }
 
 bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const

--- a/src/Cylinder.cpp
+++ b/src/Cylinder.cpp
@@ -5,9 +5,10 @@ namespace rt
 {
 Cylinder::Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h,
                    int oid, int mid)
-    : center(c), axis(axis_.normalized()), radius(r), height(h), object_id(oid),
-      material_id(mid)
+    : center(c), axis(axis_.normalized()), radius(r), height(h)
 {
+  object_id = oid;
+  material_id = mid;
 }
 
 bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -101,11 +101,6 @@ inline bool parse_rgba(std::string_view sv, rt::Vec3 &out, double &a)
 }
 inline double alpha_to_unit(double a) { return a / 255.0; }
 
-inline rt::Vec3 reflect(const rt::Vec3 &v, const rt::Vec3 &n)
-{
-  return v - n * (2.0 * rt::Vec3::dot(v, n));
-}
-
 } // namespace
 
 namespace rt
@@ -298,48 +293,6 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
       }
     }
     // TODO: textures...
-  }
-
-  // Trim beams and add reflections
-  for (size_t i = 0; i < outScene.objects.size(); ++i)
-  {
-    auto obj = outScene.objects[i];
-    if (!obj->is_beam())
-      continue;
-    Beam *bm = static_cast<Beam *>(obj.get());
-    Ray forward(bm->path.orig, bm->path.dir);
-    HitRecord tmp, hit_rec;
-    bool hit_any = false;
-    double closest = bm->length;
-    for (auto &other : outScene.objects)
-    {
-      if (other.get() == bm)
-        continue;
-      if (other->hit(forward, 1e-4, closest, tmp))
-      {
-        closest = tmp.t;
-        hit_rec = tmp;
-        hit_any = true;
-      }
-    }
-    if (hit_any)
-    {
-      bm->length = closest;
-      if (materials[hit_rec.material_id].mirror)
-      {
-        double new_start = bm->start + closest;
-        double new_len = bm->total_length - new_start;
-        if (new_len > 1e-4)
-        {
-          Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
-          Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
-          auto new_bm = std::make_shared<Beam>(refl_orig, refl_dir, bm->radius,
-                                               new_len, oid++, bm->material_id,
-                                               new_start, bm->total_length);
-          outScene.objects.push_back(new_bm);
-        }
-      }
-    }
   }
 
   outCamera =

--- a/src/Plane.cpp
+++ b/src/Plane.cpp
@@ -4,8 +4,10 @@
 namespace rt
 {
 Plane::Plane(const Vec3 &p, const Vec3 &n, int oid, int mid)
-    : point(p), normal(n.normalized()), object_id(oid), material_id(mid)
+    : point(p), normal(n.normalized())
 {
+  object_id = oid;
+  material_id = mid;
 }
 
 bool Plane::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -328,6 +328,7 @@ void Renderer::render_window(std::vector<Material> &mats,
         {
           scene.objects[selected_obj]->rotate(cam.up, -e.motion.xrel * sens);
           scene.objects[selected_obj]->rotate(cam.right, -e.motion.yrel * sens);
+          scene.update_beams(mats);
           scene.build_bvh();
         }
         else
@@ -339,6 +340,7 @@ void Renderer::render_window(std::vector<Material> &mats,
       {
         double step = e.wheel.y * 1.0;
         scene.objects[selected_obj]->translate(cam.up * step);
+        scene.update_beams(mats);
         scene.build_bvh();
       }
       else if (focused && e.type == SDL_KEYDOWN &&
@@ -362,6 +364,7 @@ void Renderer::render_window(std::vector<Material> &mats,
       if (move.length_squared() > 0)
       {
         scene.objects[selected_obj]->translate(move);
+        scene.update_beams(mats);
         scene.build_bvh();
       }
     }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,7 +1,89 @@
 #include "rt/Scene.hpp"
+#include "rt/Beam.hpp"
+#include <algorithm>
+
+namespace
+{
+inline rt::Vec3 reflect(const rt::Vec3 &v, const rt::Vec3 &n)
+{
+  return v - n * (2.0 * rt::Vec3::dot(v, n));
+}
+} // namespace
 
 namespace rt
 {
+void Scene::update_beams(const std::vector<Material> &mats)
+{
+  std::vector<std::shared_ptr<Beam>> roots;
+  std::vector<HittablePtr> non_beams;
+  non_beams.reserve(objects.size());
+
+  for (auto &obj : objects)
+  {
+    if (obj->is_beam())
+    {
+      auto bm = std::static_pointer_cast<Beam>(obj);
+      if (bm->start <= 0.0)
+      {
+        bm->start = 0.0;
+        bm->length = bm->total_length;
+        roots.push_back(bm);
+      }
+      continue;
+    }
+    non_beams.push_back(obj);
+  }
+
+  for (size_t i = 0; i < non_beams.size(); ++i)
+    non_beams[i]->object_id = static_cast<int>(i);
+
+  objects = std::move(non_beams);
+  int next_oid = static_cast<int>(objects.size());
+
+  std::vector<std::shared_ptr<Beam>> to_process = roots;
+  for (size_t i = 0; i < to_process.size(); ++i)
+  {
+    auto bm = to_process[i];
+    bm->object_id = next_oid;
+    objects.push_back(bm);
+    ++next_oid;
+
+    Ray forward(bm->path.orig, bm->path.dir);
+    HitRecord tmp, hit_rec;
+    bool hit_any = false;
+    double closest = bm->length;
+    for (auto &other : objects)
+    {
+      if (other.get() == bm.get())
+        continue;
+      if (other->hit(forward, 1e-4, closest, tmp))
+      {
+        closest = tmp.t;
+        hit_rec = tmp;
+        hit_any = true;
+      }
+    }
+    if (hit_any)
+    {
+      bm->length = closest;
+      if (mats[hit_rec.material_id].mirror)
+      {
+        double new_start = bm->start + closest;
+        double new_len = bm->total_length - new_start;
+        if (new_len > 1e-4)
+        {
+          Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
+          Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
+          auto new_bm = std::make_shared<Beam>(refl_orig, refl_dir, bm->radius,
+                                               new_len, 0, bm->material_id,
+                                               new_start, bm->total_length);
+          to_process.push_back(new_bm);
+        }
+      }
+    }
+  }
+}
+
 void Scene::build_bvh()
 {
   if (objects.empty())

--- a/src/Sphere.cpp
+++ b/src/Sphere.cpp
@@ -4,8 +4,10 @@
 namespace rt
 {
 Sphere::Sphere(const Vec3 &c, double r, int oid, int mid)
-    : center(c), radius(r), object_id(oid), material_id(mid)
+    : center(c), radius(r)
 {
+  object_id = oid;
+  material_id = mid;
 }
 
 bool Sphere::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ int main(int argc, char **argv)
     return 2;
   }
   auto mats = rt::Parser::get_materials();
+  scene.update_beams(mats);
   scene.build_bvh();
 
   rt::RenderSettings rset;


### PR DESCRIPTION
## Summary
- Recompute beam reflections whenever scene geometry changes
- Track object and material IDs on base hittable type for easier updates

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b1545be954832f8d3d70dd445a05e3