### PR TITLE
Prevent object intersection during edits

### DIFF
--- a/include/rt/AABB.hpp
+++ b/include/rt/AABB.hpp
@@ -15,6 +15,7 @@ struct AABB
   AABB(const Vec3 &a, const Vec3 &b);
 
   bool hit(const Ray &r, double tmin, double tmax) const;
+  bool intersects(const AABB &other) const;
   static AABB surrounding_box(const AABB &box0, const AABB &box1);
 };
 } // namespace rt

--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -19,6 +19,10 @@ struct Scene
   void update_beams(const std::vector<Material> &mats);
   void build_bvh();
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
+  bool try_translate(int obj_id, const Vec3 &delta);
+  bool try_rotate(int obj_id, const Vec3 &axis, double angle);
+private:
+  bool intersects_any(const AABB &box, int skip) const;
 };
 
 } // namespace rt

--- a/src/AABB.cpp
+++ b/src/AABB.cpp
@@ -32,6 +32,13 @@ bool AABB::hit(const Ray &r, double tmin, double tmax) const
   return true;
 }
 
+bool AABB::intersects(const AABB &other) const
+{
+  return (max.x >= other.min.x && min.x <= other.max.x &&
+          max.y >= other.min.y && min.y <= other.max.y &&
+          max.z >= other.min.z && min.z <= other.max.z);
+}
+
 AABB AABB::surrounding_box(const AABB &box0, const AABB &box1)
 {
   Vec3 small(std::min(box0.min.x, box1.min.x), std::min(box0.min.y, box1.min.y),

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -326,10 +326,14 @@ void Renderer::render_window(std::vector<Material> &mats,
         double sens = 0.002;
         if (edit_mode && selected_obj != -1)
         {
-          scene.objects[selected_obj]->rotate(cam.up, -e.motion.xrel * sens);
-          scene.objects[selected_obj]->rotate(cam.right, -e.motion.yrel * sens);
-          scene.update_beams(mats);
-          scene.build_bvh();
+          bool rotated = false;
+          rotated |= scene.try_rotate(selected_obj, cam.up, -e.motion.xrel * sens);
+          rotated |= scene.try_rotate(selected_obj, cam.right, -e.motion.yrel * sens);
+          if (rotated)
+          {
+            scene.update_beams(mats);
+            scene.build_bvh();
+          }
         }
         else
         {
@@ -339,9 +343,11 @@ void Renderer::render_window(std::vector<Material> &mats,
       else if (edit_mode && selected_obj != -1 && e.type == SDL_MOUSEWHEEL)
       {
         double step = e.wheel.y * 1.0;
-        scene.objects[selected_obj]->translate(cam.up * step);
-        scene.update_beams(mats);
-        scene.build_bvh();
+        if (scene.try_translate(selected_obj, cam.up * step))
+        {
+          scene.update_beams(mats);
+          scene.build_bvh();
+        }
       }
       else if (focused && e.type == SDL_KEYDOWN &&
                e.key.keysym.scancode == SDL_SCANCODE_ESCAPE)
@@ -363,9 +369,11 @@ void Renderer::render_window(std::vector<Material> &mats,
         move += cam.right * speed;
       if (move.length_squared() > 0)
       {
-        scene.objects[selected_obj]->translate(move);
-        scene.update_beams(mats);
-        scene.build_bvh();
+        if (scene.try_translate(selected_obj, move))
+        {
+          scene.update_beams(mats);
+          scene.build_bvh();
+        }
       }
     }
     else if (focused)

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -116,4 +116,47 @@ bool Scene::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
   return hit_any;
 }
 
+bool Scene::intersects_any(const AABB &box, int skip) const
+{
+  for (size_t i = 0; i < objects.size(); ++i)
+  {
+    if (static_cast<int>(i) == skip)
+      continue;
+    AABB other;
+    if (objects[i]->bounding_box(other) && box.intersects(other))
+      return true;
+  }
+  return false;
+}
+
+bool Scene::try_translate(int obj_id, const Vec3 &delta)
+{
+  auto obj = objects[obj_id];
+  obj->translate(delta);
+  AABB box;
+  if (!obj->bounding_box(box))
+    return true;
+  if (intersects_any(box, obj_id))
+  {
+    obj->translate(delta * -1.0);
+    return false;
+  }
+  return true;
+}
+
+bool Scene::try_rotate(int obj_id, const Vec3 &axis, double angle)
+{
+  auto obj = objects[obj_id];
+  obj->rotate(axis, angle);
+  AABB box;
+  if (!obj->bounding_box(box))
+    return true;
+  if (intersects_any(box, obj_id))
+  {
+    obj->rotate(axis, -angle);
+    return false;
+  }
+  return true;
+}
+
 } // namespace rt


### PR DESCRIPTION
## Summary
- add AABB::intersects helper for collision checks
- block translations or rotations that would overlap objects
- update renderer to use scene collision checks when editing

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b162857290832f8d299d1319fbcda8