### PR TITLE
Fix missing cstring include and pthread link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,5 @@ find_package(Threads REQUIRED)
 
 find_package(SDL2 REQUIRED)
 
-target_include_directories(minirt PRIVATE ${SDL2_INCLUDE_DIRS})
-target_link_libraries(minirt PRIVATE ${SDL2_LIBRARIES})
+target_include_directories(minirt PRIVATE ${SDL2_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(minirt PRIVATE ${SDL2_LIBRARIES} Threads::Threads)

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <sstream>
 #include <string_view>
+#include <cstring>
 
 namespace
 {
@@ -27,7 +28,7 @@ inline bool to_double(std::string_view sv, double &out)
   // awaryjnie, gdy libstdc++ ma słabe from_chars dla double (stare systemy)
   char buf[128];
   size_t n = std::min(sv.size(), sizeof(buf) - 1);
-  memcpy(buf, sv.data(), n);
+  std::memcpy(buf, sv.data(), n);
   buf[n] = 0;
   char *end = nullptr;
   out = std::strtod(buf, &end);


### PR DESCRIPTION
## Summary
- include `<cstring>` and use `std::memcpy` in parser helper
- link with pthreads and add project include directory in CMake

## Testing
- `cmake .. && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68b16b2e0574832f97d65b2c409dc2a5