### PR TITLE
Fix bounding boxes for rotated cylinder and cone

### DIFF
--- a/src/Cone.cpp
+++ b/src/Cone.cpp
@@ -88,9 +88,10 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 bool Cone::bounding_box(AABB &out) const
 {
   Vec3 ax = axis * (height * 0.5);
+  Vec3 abs_ax(std::fabs(ax.x), std::fabs(ax.y), std::fabs(ax.z));
   Vec3 ex(radius, radius, radius);
-  Vec3 min = center - ax - ex;
-  Vec3 max = center + ax + ex;
+  Vec3 min = center - abs_ax - ex;
+  Vec3 max = center + abs_ax + ex;
   out = AABB(min, max);
   return true;
 }

--- a/src/Cylinder.cpp
+++ b/src/Cylinder.cpp
@@ -108,9 +108,10 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 bool Cylinder::bounding_box(AABB &out) const
 {
   Vec3 ax = axis * (height / 2);
+  Vec3 abs_ax(std::fabs(ax.x), std::fabs(ax.y), std::fabs(ax.z));
   Vec3 ex(radius, radius, radius);
-  Vec3 min = center - ax - ex;
-  Vec3 max = center + ax + ex;
+  Vec3 min = center - abs_ax - ex;
+  Vec3 max = center + abs_ax + ex;
   out = AABB(min, max);
   return true;
 }


### PR DESCRIPTION
## Summary
- compute bounding boxes using absolute axis components so rotated shapes are fully enclosed

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68b16d004e7c832f9cd229102ebca15e