### PR TITLE
Fix camera control inconsistency on WSL2

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -3,11 +3,12 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <iostream>
-#include <cstring>
-#include <string>
 #include <random>
+#include <string>
 #include <thread>
 
 namespace rt
@@ -215,6 +216,8 @@ void Renderer::render_window(std::vector<Material> &mats,
     std::cerr << "SDL_Init Error: " << SDL_GetError() << "\n";
     return;
   }
+  if (std::getenv("WSL_DISTRO_NAME"))
+    SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1");
   SDL_Window *win =
       SDL_CreateWindow("MiniRT", SDL_WINDOWPOS_UNDEFINED,
                        SDL_WINDOWPOS_UNDEFINED, W, H, 0);
@@ -323,8 +326,7 @@ void Renderer::render_window(std::vector<Material> &mats,
       }
       else if (focused && e.type == SDL_MOUSEMOTION)
       {
-        // Lowered to keep camera control consistent across native Linux and WSL2
-        double sens = 0.001;
+        double sens = 0.002;
         if (edit_mode && selected_obj != -1)
         {
           scene.objects[selected_obj]->rotate(cam.up, -e.motion.xrel * sens);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -303,7 +303,7 @@ void Renderer::render_window(std::vector<Material> &mats,
         SDL_SetRelativeMouseMode(SDL_TRUE);
         SDL_ShowCursor(SDL_DISABLE);
         SDL_SetWindowGrab(win, SDL_TRUE);
-        SDL_WarpMouseInWindow(win, W / 2, H / 2);
+        SDL_GetRelativeMouseState(nullptr, nullptr);
         if (edit_mode)
         {
           if (selected_obj == -1 && hover_obj >= 0)

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -323,7 +323,8 @@ void Renderer::render_window(std::vector<Material> &mats,
       }
       else if (focused && e.type == SDL_MOUSEMOTION)
       {
-        double sens = 0.002;
+        // Lowered to keep camera control consistent across native Linux and WSL2
+        double sens = 0.001;
         if (edit_mode && selected_obj != -1)
         {
           scene.objects[selected_obj]->rotate(cam.up, -e.motion.xrel * sens);


### PR DESCRIPTION
## Summary
- Reset relative mouse movement without warping cursor when capturing mouse

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b16d511f08832f978b60175c6d5c90