### PR TITLE
Allow cube rotation

### DIFF
--- a/include/rt/Cube.hpp
+++ b/include/rt/Cube.hpp
@@ -7,10 +7,14 @@ struct Cube : public Hittable
 {
   Vec3 center;
   double half;
+  // Local orthonormal basis representing cube orientation
+  Vec3 axis[3];
+
   Cube(const Vec3 &c, double a, int oid, int mid);
 
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
+  void rotate(const Vec3 &axis, double angle) override;
 };
 } // namespace rt

--- a/src/Cube.cpp
+++ b/src/Cube.cpp
@@ -1,33 +1,48 @@
 #include "rt/Cube.hpp"
+#include <algorithm>
 #include <cmath>
 
 namespace rt
 {
 Cube::Cube(const Vec3 &c, double a, int oid, int mid) : center(c), half(a / 2.0)
 {
+  axis[0] = Vec3(1, 0, 0);
+  axis[1] = Vec3(0, 1, 0);
+  axis[2] = Vec3(0, 0, 1);
   object_id = oid;
   material_id = mid;
 }
 
 bool Cube::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
-  Vec3 min = center - Vec3(half, half, half);
-  Vec3 max = center + Vec3(half, half, half);
+  Vec3 oc = r.orig - center;
+  double orig[3] = {Vec3::dot(oc, axis[0]), Vec3::dot(oc, axis[1]),
+                    Vec3::dot(oc, axis[2])};
+  double dir[3] = {Vec3::dot(r.dir, axis[0]), Vec3::dot(r.dir, axis[1]),
+                   Vec3::dot(r.dir, axis[2])};
 
   double tmin_local = tmin;
   double tmax_local = tmax;
-  for (int axis = 0; axis < 3; ++axis)
+  Vec3 normal_local;
+  for (int i = 0; i < 3; ++i)
   {
-    double origin = axis == 0 ? r.orig.x : (axis == 1 ? r.orig.y : r.orig.z);
-    double direction = axis == 0 ? r.dir.x : (axis == 1 ? r.dir.y : r.dir.z);
-    double invD = 1.0 / direction;
-    double t0 = ((axis == 0 ? min.x : (axis == 1 ? min.y : min.z)) - origin) * invD;
-    double t1 = ((axis == 0 ? max.x : (axis == 1 ? max.y : max.z)) - origin) * invD;
+    double invD = 1.0 / dir[i];
+    double t0 = (-half - orig[i]) * invD;
+    double t1 = (half - orig[i]) * invD;
+    Vec3 n0 = i == 0 ? Vec3(-1, 0, 0)
+                     : (i == 1 ? Vec3(0, -1, 0) : Vec3(0, 0, -1));
+    Vec3 n1 = i == 0 ? Vec3(1, 0, 0)
+                     : (i == 1 ? Vec3(0, 1, 0) : Vec3(0, 0, 1));
     if (invD < 0.0)
     {
       std::swap(t0, t1);
+      std::swap(n0, n1);
     }
-    tmin_local = t0 > tmin_local ? t0 : tmin_local;
+    if (t0 > tmin_local)
+    {
+      tmin_local = t0;
+      normal_local = n0;
+    }
     tmax_local = t1 < tmax_local ? t1 : tmax_local;
     if (tmax_local <= tmin_local)
     {
@@ -39,30 +54,48 @@ bool Cube::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
   rec.material_id = material_id;
   rec.object_id = object_id;
 
-  const double eps = 1e-6;
-  Vec3 outward(0, 0, 0);
-  if (std::fabs(rec.p.x - min.x) < eps)
-    outward = Vec3(-1, 0, 0);
-  else if (std::fabs(rec.p.x - max.x) < eps)
-    outward = Vec3(1, 0, 0);
-  else if (std::fabs(rec.p.y - min.y) < eps)
-    outward = Vec3(0, -1, 0);
-  else if (std::fabs(rec.p.y - max.y) < eps)
-    outward = Vec3(0, 1, 0);
-  else if (std::fabs(rec.p.z - min.z) < eps)
-    outward = Vec3(0, 0, -1);
-  else
-    outward = Vec3(0, 0, 1);
-
-  rec.set_face_normal(r, outward);
+  Vec3 normal_world = normal_local.x * axis[0] +
+                      normal_local.y * axis[1] +
+                      normal_local.z * axis[2];
+  rec.set_face_normal(r, normal_world);
   return true;
 }
 
 bool Cube::bounding_box(AABB &out) const
 {
-  Vec3 rad(half, half, half);
-  out = AABB(center - rad, center + rad);
+  Vec3 u = axis[0] * half;
+  Vec3 v = axis[1] * half;
+  Vec3 w = axis[2] * half;
+  Vec3 corners[8] = {center - u - v - w, center - u - v + w,
+                     center - u + v - w, center - u + v + w,
+                     center + u - v - w, center + u - v + w,
+                     center + u + v - w, center + u + v + w};
+  Vec3 min = corners[0];
+  Vec3 max = corners[0];
+  for (int i = 1; i < 8; ++i)
+  {
+    min.x = std::min(min.x, corners[i].x);
+    min.y = std::min(min.y, corners[i].y);
+    min.z = std::min(min.z, corners[i].z);
+    max.x = std::max(max.x, corners[i].x);
+    max.y = std::max(max.y, corners[i].y);
+    max.z = std::max(max.z, corners[i].z);
+  }
+  out = AABB(min, max);
   return true;
+}
+
+void Cube::rotate(const Vec3 &ax, double angle)
+{
+  auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang) {
+    double c = std::cos(ang);
+    double s = std::sin(ang);
+    return v * c + Vec3::cross(axis, v) * s +
+           axis * Vec3::dot(axis, v) * (1 - c);
+  };
+  axis[0] = rotate_vec(axis[0], ax, angle).normalized();
+  axis[1] = rotate_vec(axis[1], ax, angle).normalized();
+  axis[2] = rotate_vec(axis[2], ax, angle).normalized();
 }
 
 } // namespace rt


### PR DESCRIPTION
## Summary
- enable orientation and rotation support for cube objects
- implement ray intersection and bounding box for rotated cubes

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b17d7f4304832f9dfb6c3ff77b3982