### PR TITLE
Clamp camera pitch to prevent 180° flip

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -26,7 +26,11 @@ void Camera::rotate(double yaw, double pitch)
   };
   forward = rotate_vec(forward, world_up, yaw);
   right = Vec3::cross(forward, world_up).normalized();
-  forward = rotate_vec(forward, right, pitch);
+
+  Vec3 new_forward = rotate_vec(forward, right, pitch);
+  if (std::abs(Vec3::dot(new_forward, world_up)) < 0.9999)
+    forward = new_forward;
+
   up = Vec3::cross(right, forward).normalized();
 }
 


### PR DESCRIPTION
## Summary
- prevent camera orientation from flipping when looking straight up or down by clamping pitch

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b17fd8af04832fa843925d22b4a413