### PR TITLE
Enable vertical camera movement via scroll

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -343,6 +343,11 @@ void Renderer::render_window(std::vector<Material> &mats,
         scene.update_beams(mats);
         scene.build_bvh();
       }
+      else if (!edit_mode && focused && e.type == SDL_MOUSEWHEEL)
+      {
+        double step = e.wheel.y * 1.0;
+        cam.move(cam.up * step);
+      }
       else if (focused && e.type == SDL_KEYDOWN &&
                e.key.keysym.scancode == SDL_SCANCODE_ESCAPE)
         running = false;


### PR DESCRIPTION
## Summary
- add camera movement using mouse wheel when in spectator mode

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b182a840d8832f9f19dff5e1e0978c