### PR TITLE
Enable building on Windows via MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,13 @@ file(GLOB SRC_FILES CONFIGURE_DEPENDS src/*.cpp)
 add_executable(minirt ${SRC_FILES})
 
 find_package(Threads REQUIRED)
+target_include_directories(minirt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-find_package(SDL2 REQUIRED)
-
-target_include_directories(minirt PRIVATE ${SDL2_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(minirt PRIVATE ${SDL2_LIBRARIES} Threads::Threads)
+if (WIN32)
+    find_package(SDL2 CONFIG REQUIRED)
+    target_link_libraries(minirt PRIVATE SDL2::SDL2main SDL2::SDL2 Threads::Threads)
+else()
+    find_package(SDL2 REQUIRED)
+    target_include_directories(minirt PRIVATE ${SDL2_INCLUDE_DIRS})
+    target_link_libraries(minirt PRIVATE ${SDL2_LIBRARIES} Threads::Threads)
+endif()

--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ cmake -S . -B build
 cmake --build build
 ```
 
+### Windows (MSYS2)
+1. Install [MSYS2](https://www.msys2.org/) and open the **MSYS2 UCRT64** shell.
+2. Update the system and install dependencies:
+   ```bash
+   pacman -Syu
+   pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain \
+       mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ninja \
+       mingw-w64-ucrt-x86_64-SDL2
+   ```
+3. Configure and build the project:
+   ```bash
+   cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+   cmake --build build -j
+   ```
+   (Use `-G "MinGW Makefiles"` instead of Ninja if you prefer make.)
+4. Run the executable:
+   ```bash
+   ./build/minirt.exe
+   ```
+
 ## Run
 After building, run the renderer with a scene file:
 ```bash

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,5 +1,5 @@
 #include "rt/Renderer.hpp"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <algorithm>
 #include <atomic>
 #include <cmath>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,8 @@
 #include "rt/Parser.hpp"   // single translation include for brevity
 #include "rt/Renderer.hpp" // same trick
 #include "rt/Scene.hpp"
+#include <SDL.h>
+#include <SDL_main.h>
 #include <iostream>
 #include <thread>
 


### PR DESCRIPTION
## Summary
- Configure CMake to use SDL2 imported targets on Windows (MSYS2) while keeping existing Linux support.
- Include SDL headers in main entry point and switch renderer to <SDL.h> for cross-platform builds.
- Document build steps for MSYS2/Windows in the README.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `./build/minirt`

------
https://chatgpt.com/codex/tasks/task_e_68b185aa242c832f806bb3135f8290c2