### PR TITLE
docs: clarify run instructions for Windows and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,26 @@ cmake --build build
     ```
 
 ## Run
-After building, run the renderer with a scene file:
+
+### Windows (MSYS2)
+After building, launch the game from the MSYS2 shell:
+```bash
+./build/minirt.exe scenes/test.rt [width height threads]
+```
+Example with optional arguments:
+```bash
+./build/minirt.exe scenes/test.rt 1024 768 4
+```
+
+### Linux (Ubuntu)
+After building, run the renderer:
 ```bash
 ./build/minirt scenes/test.rt [width height threads]
 ```
+Example with optional arguments:
+```bash
+./build/minirt scenes/test.rt 1024 768 4
+```
+
 Optional `width`, `height`, and `threads` arguments control the output image size and number of rendering threads. The `scenes` directory contains sample `.rt` files.
 


### PR DESCRIPTION
## Summary
- document running the executable under Windows/MSYS2 and Linux/Ubuntu
- add example commands showing optional width, height, and thread arguments

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_68b18f7620bc832f8e8d4b49f2b75c0f