### PR TITLE
Fix beam intersection for internal rays

### DIFF
--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -37,19 +37,38 @@ bool Beam::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
     tc = (a * e - b * d) / denom;
   }
 
-  if (sc < tmin || sc > tmax)
-    return false;
-  if (tc < 0.0 || tc > length)
-    return false;
-
-  Vec3 pr = r.at(sc);
-  Vec3 pb = path.at(tc);
-  Vec3 diff = pr - pb;
-  double dist2 = diff.length_squared();
-  if (dist2 > radius * radius)
-    return false;
+  Vec3 pb;
+  Vec3 pr;
+  Vec3 diff;
+  if (sc < tmin)
+  {
+    double tc0 = e / c;
+    if (tc0 < 0.0 || tc0 > length)
+      return false;
+    pb = path.at(tc0);
+    Vec3 from_origin = r.orig - pb;
+    if (from_origin.length_squared() > radius * radius)
+      return false;
+    tc = tc0;
+    sc = tmin;
+    pr = r.at(sc);
+    diff = from_origin;
+  }
+  else
+  {
+    if (sc > tmax)
+      return false;
+    if (tc < 0.0 || tc > length)
+      return false;
+    pb = path.at(tc);
+    pr = r.at(sc);
+    diff = pr - pb;
+    if (diff.length_squared() > radius * radius)
+      return false;
+  }
 
   Vec3 outward;
+  double dist2 = diff.length_squared();
   if (dist2 > 1e-12)
   {
     outward = diff.normalized();


### PR DESCRIPTION
## Summary
- Correct beam hit logic to detect rays that originate inside the beam cylinder.

## Testing
- `cmake --build build`
- `g++ /tmp/test_beam.cpp src/Beam.cpp src/Ray.cpp src/Vec3.cpp src/Hittable.cpp src/AABB.cpp -Iinclude -std=c++17 -o /tmp/test_beam`
- `/tmp/test_beam`


------
https://chatgpt.com/codex/tasks/task_e_68b19038f898832f8a89cabfe9e76a40