### PR TITLE
Use BVH for faster shadow queries

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -16,18 +16,17 @@ namespace rt
 
 static bool in_shadow(const Scene &scene, const Vec3 &p, const Vec3 &light_pos)
 {
-  Vec3 dir = (light_pos - p).normalized();
+  Vec3 to_light = light_pos - p;
+  Vec3 dir = to_light.normalized();
   Ray shadow_ray(p + dir * 1e-4, dir);
-  double dist_to_light = (light_pos - p).length();
+  double dist_to_light = to_light.length();
   HitRecord tmp;
-  for (const auto &obj : scene.objects)
+  double tmin = 1e-4;
+  while (scene.hit(shadow_ray, tmin, dist_to_light - 1e-4, tmp))
   {
-    if (obj->is_beam())
-      continue;
-    if (obj->hit(shadow_ray, 1e-4, dist_to_light - 1e-4, tmp))
-    {
+    if (!scene.objects[tmp.object_id]->is_beam())
       return true;
-    }
+    tmin = tmp.t + 1e-4;
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- Optimize shadow visibility checks by leveraging the scene's BVH and skipping beam objects efficiently.

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68b20eaaba70832f98c7768461326820