### PR TITLE
Add configurable antialiasing samples

### DIFF
--- a/include/rt/Renderer.hpp
+++ b/include/rt/Renderer.hpp
@@ -14,6 +14,7 @@ struct RenderSettings
   int height = 600;
   int threads = 0; // 0 => auto
   float downscale = 1.0f; // 1.0 => full res, 1.5 => medium, 2.0 => low
+  int samples = 1; // samples per pixel for antialiasing
 };
 
 class Renderer

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -167,11 +167,15 @@ void Renderer::render_ppm(const std::string &path,
         break;
       for (int x = 0; x < W; ++x)
       {
-        double u = (x + 0.5) / W;
-        double v = (y + 0.5) / H;
-        Ray r = cam.ray_through(u, v);
-        Vec3 col = trace_ray(scene, mats, r, rng, dist);
-        framebuffer[y * W + x] = col;
+        Vec3 col(0.0, 0.0, 0.0);
+        for (int s = 0; s < rset.samples; ++s)
+        {
+          double u = (x + dist(rng)) / W;
+          double v = (y + dist(rng)) / H;
+          Ray r = cam.ray_through(u, v);
+          col += trace_ray(scene, mats, r, rng, dist);
+        }
+        framebuffer[y * W + x] = col / static_cast<double>(rset.samples);
       }
     }
   };
@@ -423,11 +427,15 @@ void Renderer::render_window(std::vector<Material> &mats,
           break;
         for (int x = 0; x < RW; ++x)
         {
-          double u = (x + 0.5) / RW;
-          double v = (y + 0.5) / RH;
-          Ray r = cam.ray_through(u, v);
-          Vec3 col = trace_ray(scene, mats, r, rng, dist);
-          framebuffer[y * RW + x] = col;
+          Vec3 col(0.0, 0.0, 0.0);
+          for (int s = 0; s < rset.samples; ++s)
+          {
+            double u = (x + dist(rng)) / RW;
+            double v = (y + dist(rng)) / RH;
+            Ray r = cam.ray_through(u, v);
+            col += trace_ray(scene, mats, r, rng, dist);
+          }
+          framebuffer[y * RW + x] = col / static_cast<double>(rset.samples);
         }
       }
     };


### PR DESCRIPTION
## Summary
- add configurable sample count to render settings for antialiasing
- jitter and average multiple ray samples per pixel in both file and window rendering

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b21dec8d80832fae173b6b30c16e08