### PR TITLE
Rework edit mode controls

### DIFF
--- a/include/rt/Cone.hpp
+++ b/include/rt/Cone.hpp
@@ -17,6 +17,7 @@ struct Cone : public Hittable
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
   void rotate(const Vec3 &axis, double angle) override;
+  Vec3 get_center() const override { return center; }
 };
 
 } // namespace rt

--- a/include/rt/Cube.hpp
+++ b/include/rt/Cube.hpp
@@ -16,5 +16,6 @@ struct Cube : public Hittable
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
   void rotate(const Vec3 &axis, double angle) override;
+  Vec3 get_center() const override { return center; }
 };
 } // namespace rt

--- a/include/rt/Cylinder.hpp
+++ b/include/rt/Cylinder.hpp
@@ -18,6 +18,7 @@ struct Cylinder : public Hittable
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
   void rotate(const Vec3 &axis, double angle) override;
+  Vec3 get_center() const override { return center; }
 };
 
 } // namespace rt

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -41,6 +41,8 @@ struct Hittable
     (void)axis;
     (void)angle;
   }
+  // default center
+  virtual Vec3 get_center() const { return Vec3(); }
 };
 
 using HittablePtr = std::shared_ptr<Hittable>;

--- a/include/rt/Sphere.hpp
+++ b/include/rt/Sphere.hpp
@@ -15,6 +15,7 @@ struct Sphere : public Hittable
            HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
+  Vec3 get_center() const override { return center; }
 };
 
 } // namespace rt

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -32,6 +32,7 @@ static bool in_shadow(const Scene &scene, const Vec3 &p, const Vec3 &light_pos)
   return false;
 }
 
+
 static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
                       const Ray &r, std::mt19937 &rng,
                       std::uniform_real_distribution<double> &dist,
@@ -265,6 +266,8 @@ void Renderer::render_window(std::vector<Material> &mats,
   int hover_mat = -1;
   int selected_obj = -1;
   int selected_mat = -1;
+  Vec3 edit_obj_pos;
+  double edit_dist = 0.0;
 
   while (running)
   {
@@ -300,6 +303,22 @@ void Renderer::render_window(std::vector<Material> &mats,
           mats[selected_mat].checkered = true;
           mats[selected_mat].color = mats[selected_mat].base_color;
           edit_mode = true;
+          edit_obj_pos = scene.objects[selected_obj]->get_center();
+          edit_dist = Vec3::dot(edit_obj_pos - cam.origin, cam.forward);
+          Vec3 desired = cam.origin + cam.forward * edit_dist;
+          Vec3 move = desired - edit_obj_pos;
+          if (move.length_squared() > 0)
+          {
+            scene.objects[selected_obj]->translate(move);
+            if (scene.collides(selected_obj))
+              scene.objects[selected_obj]->translate(move * -1);
+            else
+            {
+              edit_obj_pos += move;
+              scene.update_beams(mats);
+              scene.build_bvh();
+            }
+          }
         }
         else if (edit_mode)
         {
@@ -311,23 +330,33 @@ void Renderer::render_window(std::vector<Material> &mats,
       }
       else if (focused && e.type == SDL_MOUSEMOTION)
       {
-        if (edit_mode)
+        Uint32 buttons = SDL_GetMouseState(nullptr, nullptr);
+        if (edit_mode && (buttons & SDL_BUTTON(SDL_BUTTON_RIGHT)))
         {
-          double sens = OBJECT_MOUSE_SENSITIVITY * dt;
-          Vec3 move = cam.right * (e.motion.xrel * sens) +
-                      cam.up * (-e.motion.yrel * sens);
-          if (move.length_squared() > 0)
+          double sens = MOUSE_SENSITIVITY;
+          bool changed = false;
+          double yaw = -e.motion.xrel * sens;
+          if (yaw != 0.0)
           {
-            scene.objects[selected_obj]->translate(move);
+            scene.objects[selected_obj]->rotate(cam.up, yaw);
             if (scene.collides(selected_obj))
-            {
-              scene.objects[selected_obj]->translate(move * -1);
-            }
+              scene.objects[selected_obj]->rotate(cam.up, -yaw);
             else
-            {
-              scene.update_beams(mats);
-              scene.build_bvh();
-            }
+              changed = true;
+          }
+          double pitch = -e.motion.yrel * sens;
+          if (pitch != 0.0)
+          {
+            scene.objects[selected_obj]->rotate(cam.right, pitch);
+            if (scene.collides(selected_obj))
+              scene.objects[selected_obj]->rotate(cam.right, -pitch);
+            else
+              changed = true;
+          }
+          if (changed)
+          {
+            scene.update_beams(mats);
+            scene.build_bvh();
           }
         }
         else
@@ -341,12 +370,16 @@ void Renderer::render_window(std::vector<Material> &mats,
         double step = e.wheel.y * SCROLL_STEP;
         if (edit_mode)
         {
-          Vec3 delta = cam.forward * step;
-          scene.objects[selected_obj]->translate(delta);
+          double new_dist = edit_dist + step;
+          Vec3 desired = cam.origin + cam.forward * new_dist;
+          Vec3 move = desired - edit_obj_pos;
+          scene.objects[selected_obj]->translate(move);
           if (scene.collides(selected_obj))
-            scene.objects[selected_obj]->translate(delta * -1);
+            scene.objects[selected_obj]->translate(move * -1);
           else
           {
+            edit_dist = new_dist;
+            edit_obj_pos += move;
             scene.update_beams(mats);
             scene.build_bvh();
           }
@@ -362,49 +395,7 @@ void Renderer::render_window(std::vector<Material> &mats,
     }
 
     const Uint8 *state = SDL_GetKeyboardState(nullptr);
-    if (edit_mode)
-    {
-      double speed = OBJECT_ROTATE_SPEED * dt;
-      bool changed = false;
-      if (state[SDL_SCANCODE_W])
-      {
-        scene.objects[selected_obj]->rotate(cam.right, speed);
-        if (scene.collides(selected_obj))
-          scene.objects[selected_obj]->rotate(cam.right, -speed);
-        else
-          changed = true;
-      }
-      if (state[SDL_SCANCODE_S])
-      {
-        scene.objects[selected_obj]->rotate(cam.right, -speed);
-        if (scene.collides(selected_obj))
-          scene.objects[selected_obj]->rotate(cam.right, speed);
-        else
-          changed = true;
-      }
-      if (state[SDL_SCANCODE_A])
-      {
-        scene.objects[selected_obj]->rotate(cam.up, speed);
-        if (scene.collides(selected_obj))
-          scene.objects[selected_obj]->rotate(cam.up, -speed);
-        else
-          changed = true;
-      }
-      if (state[SDL_SCANCODE_D])
-      {
-        scene.objects[selected_obj]->rotate(cam.up, -speed);
-        if (scene.collides(selected_obj))
-          scene.objects[selected_obj]->rotate(cam.up, speed);
-        else
-          changed = true;
-      }
-      if (changed)
-      {
-        scene.update_beams(mats);
-        scene.build_bvh();
-      }
-    }
-    else if (focused)
+    if (focused)
     {
       if (state[SDL_SCANCODE_ESCAPE])
         running = false;
@@ -417,6 +408,52 @@ void Renderer::render_window(std::vector<Material> &mats,
         cam.move(cam.right * -speed);
       if (state[SDL_SCANCODE_D])
         cam.move(cam.right * speed);
+    }
+    if (edit_mode && focused)
+    {
+      double rspeed = OBJECT_ROTATE_SPEED * dt;
+      bool changed = false;
+      if (state[SDL_SCANCODE_Q])
+      {
+        scene.objects[selected_obj]->rotate(cam.forward, rspeed);
+        if (scene.collides(selected_obj))
+          scene.objects[selected_obj]->rotate(cam.forward, -rspeed);
+        else
+          changed = true;
+      }
+      if (state[SDL_SCANCODE_E])
+      {
+        scene.objects[selected_obj]->rotate(cam.forward, -rspeed);
+        if (scene.collides(selected_obj))
+          scene.objects[selected_obj]->rotate(cam.forward, rspeed);
+        else
+          changed = true;
+      }
+      if (changed)
+      {
+        scene.update_beams(mats);
+        scene.build_bvh();
+      }
+    }
+
+    if (edit_mode)
+    {
+      Vec3 desired = cam.origin + cam.forward * edit_dist;
+      Vec3 move = desired - edit_obj_pos;
+      if (move.length_squared() > 0)
+      {
+        scene.objects[selected_obj]->translate(move);
+        if (scene.collides(selected_obj))
+        {
+          scene.objects[selected_obj]->translate(move * -1);
+        }
+        else
+        {
+          edit_obj_pos += move;
+          scene.update_beams(mats);
+          scene.build_bvh();
+        }
+      }
     }
 
     if (!edit_mode)


### PR DESCRIPTION
## Summary
- Let camera move freely in edit mode while selected object stays in view and moves with the camera
- Rotate selected object with right mouse (yaw/pitch) or Q/E keys (roll) and adjust distance with scroll
- Add generic center accessor to hittables for tracking object position

## Testing
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68b391522170832fbc58358df023f9d2