### PR TITLE
Add camera collision detection

### DIFF
--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -9,6 +9,7 @@
 
 namespace rt
 {
+struct Vec3;
 struct Scene
 {
   std::vector<HittablePtr> objects;
@@ -20,6 +21,7 @@ struct Scene
   void build_bvh();
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
   bool collides(int index) const;
+  bool collides(const Vec3 &point) const;
 };
 
 } // namespace rt

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -399,7 +399,9 @@ void Renderer::render_window(std::vector<Material> &mats,
         }
         else if (focused)
         {
-          cam.move(cam.up * step);
+          Vec3 delta = cam.up * step;
+          if (!scene.collides(cam.origin + delta))
+            cam.move(delta);
         }
       }
       else if (focused && e.type == SDL_KEYDOWN &&
@@ -411,14 +413,18 @@ void Renderer::render_window(std::vector<Material> &mats,
     if (edit_mode)
     {
       double cam_speed = CAMERA_MOVE_SPEED * dt;
+      Vec3 move_delta(0, 0, 0);
       if (state[SDL_SCANCODE_W])
-        cam.move(cam.forward * cam_speed);
+        move_delta += cam.forward * cam_speed;
       if (state[SDL_SCANCODE_S])
-        cam.move(cam.forward * -cam_speed);
+        move_delta += cam.forward * -cam_speed;
       if (state[SDL_SCANCODE_A])
-        cam.move(cam.right * -cam_speed);
+        move_delta += cam.right * -cam_speed;
       if (state[SDL_SCANCODE_D])
-        cam.move(cam.right * cam_speed);
+        move_delta += cam.right * cam_speed;
+      if (move_delta.length_squared() > 0 &&
+          !scene.collides(cam.origin + move_delta))
+        cam.move(move_delta);
 
       double rot_speed = OBJECT_ROTATE_SPEED * dt;
       bool changed = false;
@@ -449,14 +455,18 @@ void Renderer::render_window(std::vector<Material> &mats,
       if (state[SDL_SCANCODE_ESCAPE])
         running = false;
       double speed = CAMERA_MOVE_SPEED * dt;
+      Vec3 move_delta(0, 0, 0);
       if (state[SDL_SCANCODE_W])
-        cam.move(cam.forward * speed);
+        move_delta += cam.forward * speed;
       if (state[SDL_SCANCODE_S])
-        cam.move(cam.forward * -speed);
+        move_delta += cam.forward * -speed;
       if (state[SDL_SCANCODE_A])
-        cam.move(cam.right * -speed);
+        move_delta += cam.right * -speed;
       if (state[SDL_SCANCODE_D])
-        cam.move(cam.right * speed);
+        move_delta += cam.right * speed;
+      if (move_delta.length_squared() > 0 &&
+          !scene.collides(cam.origin + move_delta))
+        cam.move(move_delta);
     }
 
     if (edit_mode)

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -102,6 +102,29 @@ void Scene::build_bvh()
   accel = std::make_shared<BVHNode>(objs, 0, objs.size());
 }
 
+bool Scene::collides(const Vec3 &point) const
+{
+  for (const auto &obj : objects)
+  {
+    if (obj->is_beam())
+      continue;
+    if (obj->is_plane())
+    {
+      auto pl = std::static_pointer_cast<Plane>(obj);
+      if (Vec3::dot(point - pl->point, pl->normal) < 0)
+        return true;
+      continue;
+    }
+    AABB box;
+    if (!obj->bounding_box(box))
+      continue;
+    if (point.x > box.min.x && point.x < box.max.x && point.y > box.min.y &&
+        point.y < box.max.y && point.z > box.min.z && point.z < box.max.z)
+      return true;
+  }
+  return false;
+}
+
 bool Scene::collides(int index) const
 {
   if (index < 0 || index >= static_cast<int>(objects.size()))


### PR DESCRIPTION
## Summary
- Prevent camera from moving through scene geometry by checking potential collisions before applying movement
- Add point-based collision helper in Scene that ignores beams and respects planes

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68b397753a5c832f96e41d26c9550432