### PR TITLE
Introduce matrix-based object transforms

### DIFF
--- a/include/rt/Mat4.hpp
+++ b/include/rt/Mat4.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include "Vec3.hpp"
+#include <cmath>
+
+namespace rt {
+
+struct Mat4 {
+  double m[4][4];
+  Mat4();
+  static Mat4 identity();
+  static Mat4 translate(const Vec3 &t);
+  static Mat4 scale(const Vec3 &s);
+  static Mat4 rotate(const Vec3 &axis, double angle);
+  static Mat4 rotate_from_to(const Vec3 &from, const Vec3 &to);
+  Mat4 operator*(const Mat4 &o) const;
+  Vec3 apply_point(const Vec3 &p) const;
+  Vec3 apply_vector(const Vec3 &v) const;
+};
+
+}

--- a/src/Mat4.cpp
+++ b/src/Mat4.cpp
@@ -1,0 +1,100 @@
+#include "rt/Mat4.hpp"
+
+namespace rt {
+
+Mat4::Mat4() {
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j)
+      m[i][j] = 0.0;
+}
+
+Mat4 Mat4::identity() {
+  Mat4 r;
+  for (int i = 0; i < 4; ++i)
+    r.m[i][i] = 1.0;
+  return r;
+}
+
+Mat4 Mat4::translate(const Vec3 &t) {
+  Mat4 r = Mat4::identity();
+  r.m[0][3] = t.x;
+  r.m[1][3] = t.y;
+  r.m[2][3] = t.z;
+  return r;
+}
+
+Mat4 Mat4::scale(const Vec3 &s) {
+  Mat4 r = Mat4::identity();
+  r.m[0][0] = s.x;
+  r.m[1][1] = s.y;
+  r.m[2][2] = s.z;
+  return r;
+}
+
+Mat4 Mat4::rotate(const Vec3 &axis, double angle) {
+  Vec3 a = axis.normalized();
+  double c = std::cos(angle);
+  double s = std::sin(angle);
+  double t = 1.0 - c;
+  Mat4 r = Mat4::identity();
+  r.m[0][0] = c + a.x * a.x * t;
+  r.m[0][1] = a.x * a.y * t - a.z * s;
+  r.m[0][2] = a.x * a.z * t + a.y * s;
+  r.m[1][0] = a.y * a.x * t + a.z * s;
+  r.m[1][1] = c + a.y * a.y * t;
+  r.m[1][2] = a.y * a.z * t - a.x * s;
+  r.m[2][0] = a.z * a.x * t - a.y * s;
+  r.m[2][1] = a.z * a.y * t + a.x * s;
+  r.m[2][2] = c + a.z * a.z * t;
+  return r;
+}
+
+Mat4 Mat4::rotate_from_to(const Vec3 &from, const Vec3 &to) {
+  Vec3 f = from.normalized();
+  Vec3 tvec = to.normalized();
+  double cosTheta = Vec3::dot(f, tvec);
+  if (cosTheta > 0.9999)
+    return Mat4::identity();
+  if (cosTheta < -0.9999) {
+    Vec3 axis = Vec3::cross(Vec3(1, 0, 0), f);
+    if (axis.length_squared() < 1e-6)
+      axis = Vec3::cross(Vec3(0, 1, 0), f);
+    axis = axis.normalized();
+    return Mat4::rotate(axis, M_PI);
+  }
+  Vec3 axis = Vec3::cross(f, tvec);
+  double angle = std::acos(cosTheta);
+  return Mat4::rotate(axis, angle);
+}
+
+Mat4 Mat4::operator*(const Mat4 &o) const {
+  Mat4 r;
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j)
+      for (int k = 0; k < 4; ++k)
+        r.m[i][j] += m[i][k] * o.m[k][j];
+  return r;
+}
+
+Vec3 Mat4::apply_point(const Vec3 &p) const {
+  double x = m[0][0] * p.x + m[0][1] * p.y + m[0][2] * p.z + m[0][3];
+  double y = m[1][0] * p.x + m[1][1] * p.y + m[1][2] * p.z + m[1][3];
+  double z = m[2][0] * p.x + m[2][1] * p.y + m[2][2] * p.z + m[2][3];
+  double w = m[3][0] * p.x + m[3][1] * p.y + m[3][2] * p.z + m[3][3];
+  if (w != 0.0 && w != 1.0) {
+    x /= w;
+    y /= w;
+    z /= w;
+  }
+  return Vec3(x, y, z);
+}
+
+Vec3 Mat4::apply_vector(const Vec3 &v) const {
+  double x = m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z;
+  double y = m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z;
+  double z = m[2][0] * v.x + m[2][1] * v.y + m[2][2] * v.z;
+  return Vec3(x, y, z);
+}
+
+} // namespace rt
+

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -5,6 +5,7 @@
 #include "rt/Cylinder.hpp"
 #include "rt/Plane.hpp"
 #include "rt/Sphere.hpp"
+#include "rt/Mat4.hpp"
 
 #include <algorithm>
 #include <charconv>
@@ -182,7 +183,11 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
       if (parse_triple(s_pos, c) && to_double(s_r, r) &&
           parse_rgba(s_rgb, rgb, a))
       {
-        auto s = std::make_shared<Sphere>(c, r, oid++, mid);
+        Mat4 trans = Mat4::translate(c);
+        Mat4 scale = Mat4::scale(Vec3(r, r, r));
+        Vec3 world_center = (trans * scale).apply_point(Vec3(0, 0, 0));
+        double world_radius = scale.apply_vector(Vec3(1, 0, 0)).length();
+        auto s = std::make_shared<Sphere>(world_center, world_radius, oid++, mid);
         s->movable = (s_move == "M");
         materials.emplace_back();
         materials.back().color = rgb_to_unit(rgb);
@@ -208,7 +213,11 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
       if (parse_triple(s_p, p) && parse_triple(s_n, n) &&
           parse_rgba(s_rgb, rgb, a))
       {
-        auto pl = std::make_shared<Plane>(p, n, oid++, mid);
+        Mat4 trans = Mat4::translate(p);
+        Mat4 rot = Mat4::rotate_from_to(Vec3(0, 1, 0), n);
+        Vec3 world_point = trans.apply_point(Vec3(0, 0, 0));
+        Vec3 world_normal = rot.apply_vector(Vec3(0, 1, 0)).normalized();
+        auto pl = std::make_shared<Plane>(world_point, world_normal, oid++, mid);
         pl->movable = (s_move == "M");
         materials.emplace_back();
         materials.back().color = rgb_to_unit(rgb);
@@ -235,7 +244,11 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
       if (parse_triple(s_pos, c) && parse_triple(s_dir, dir) &&
           to_double(s_d, d) && to_double(s_h, h) && parse_rgba(s_rgb, rgb, a))
       {
-        auto cy = std::make_shared<Cylinder>(c, dir, d / 2.0, h, oid++, mid);
+        Mat4 trans = Mat4::translate(c);
+        Mat4 rot = Mat4::rotate_from_to(Vec3(0, 1, 0), dir);
+        Vec3 world_center = trans.apply_point(Vec3(0, 0, 0));
+        Vec3 world_axis = rot.apply_vector(Vec3(0, 1, 0)).normalized();
+        auto cy = std::make_shared<Cylinder>(world_center, world_axis, d / 2.0, h, oid++, mid);
         cy->movable = (s_move == "M");
         materials.emplace_back();
         materials.back().color = rgb_to_unit(rgb);
@@ -261,7 +274,9 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
       double alpha = 255;
       if (parse_triple(s_pos, c) && to_double(s_a, a) && parse_rgba(s_rgb, rgb, alpha))
       {
-        auto cu = std::make_shared<Cube>(c, a, oid++, mid);
+        Mat4 trans = Mat4::translate(c);
+        Vec3 world_center = trans.apply_point(Vec3(0, 0, 0));
+        auto cu = std::make_shared<Cube>(world_center, a, oid++, mid);
         cu->movable = (s_move == "M");
         materials.emplace_back();
         materials.back().color = rgb_to_unit(rgb);
@@ -309,7 +324,11 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
       if (parse_triple(s_pos, c) && parse_triple(s_dir, dir) &&
           to_double(s_d, d) && to_double(s_h, h) && parse_rgba(s_rgb, rgb, a))
       {
-        auto co = std::make_shared<Cone>(c, dir, d / 2.0, h, oid++, mid);
+        Mat4 trans = Mat4::translate(c);
+        Mat4 rot = Mat4::rotate_from_to(Vec3(0, 1, 0), dir);
+        Vec3 world_center = trans.apply_point(Vec3(0, 0, 0));
+        Vec3 world_axis = rot.apply_vector(Vec3(0, 1, 0)).normalized();
+        auto co = std::make_shared<Cone>(world_center, world_axis, d / 2.0, h, oid++, mid);
         co->movable = (s_move == "M");
         materials.emplace_back();
         materials.back().color = rgb_to_unit(rgb);


### PR DESCRIPTION
## Summary
- Add 4x4 `Mat4` utility with translation, scaling, and rotation helpers
- Parse scene objects in local space and apply matrices to compute world-space placement

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b46b6f0c24832fa9568ea2dc540438