### PR TITLE
Improve collision detection with BVH and GJK narrow phase

### DIFF
--- a/include/rt/BVH.hpp
+++ b/include/rt/BVH.hpp
@@ -19,6 +19,9 @@ struct BVHNode : public Hittable
   bool hit(const Ray &r, double tmin, double tmax,
            HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override;
+  void query(const AABB &range, std::vector<HittablePtr> &out) const;
+  bool is_bvh() const override { return true; }
+  ShapeType shape_type() const override { return ShapeType::BVH; }
 
 private:
   static int choose_axis(std::vector<HittablePtr> &objs, size_t start,

--- a/include/rt/Beam.hpp
+++ b/include/rt/Beam.hpp
@@ -17,6 +17,7 @@ struct Beam : public Hittable
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override;
   bool is_beam() const override;
+  ShapeType shape_type() const override { return ShapeType::Beam; }
 };
 
 } // namespace rt

--- a/include/rt/Collision.hpp
+++ b/include/rt/Collision.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "Hittable.hpp"
+#include <vector>
+
+namespace rt
+{
+
+bool precise_collision(const HittablePtr &a, const HittablePtr &b);
+
+}

--- a/include/rt/Cone.hpp
+++ b/include/rt/Cone.hpp
@@ -17,6 +17,7 @@ struct Cone : public Hittable
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
   void rotate(const Vec3 &axis, double angle) override;
+  ShapeType shape_type() const override { return ShapeType::Cone; }
 };
 
 } // namespace rt

--- a/include/rt/Cube.hpp
+++ b/include/rt/Cube.hpp
@@ -16,5 +16,6 @@ struct Cube : public Hittable
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
   void rotate(const Vec3 &axis, double angle) override;
+  ShapeType shape_type() const override { return ShapeType::Cube; }
 };
 } // namespace rt

--- a/include/rt/Cylinder.hpp
+++ b/include/rt/Cylinder.hpp
@@ -18,6 +18,7 @@ struct Cylinder : public Hittable
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
   void rotate(const Vec3 &axis, double angle) override;
+  ShapeType shape_type() const override { return ShapeType::Cylinder; }
 };
 
 } // namespace rt

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -8,6 +8,18 @@
 namespace rt
 {
 
+enum class ShapeType
+{
+  Generic,
+  Sphere,
+  Cube,
+  Cylinder,
+  Cone,
+  Plane,
+  BVH,
+  Beam
+};
+
 struct Material;
 
 struct HitRecord
@@ -31,8 +43,10 @@ struct Hittable
   virtual bool hit(const Ray &r, double tmin, double tmax,
                    HitRecord &rec) const = 0;
   virtual bool bounding_box(AABB &out) const = 0;
+  virtual ShapeType shape_type() const { return ShapeType::Generic; }
   virtual bool is_beam() const { return false; }
   virtual bool is_plane() const { return false; }
+  virtual bool is_bvh() const { return false; }
   // default translation does nothing
   virtual void translate(const Vec3 &delta) { (void)delta; }
   // default rotation does nothing

--- a/include/rt/Plane.hpp
+++ b/include/rt/Plane.hpp
@@ -16,6 +16,7 @@ struct Plane : public Hittable
   bool is_plane() const override { return true; }
   void translate(const Vec3 &delta) override { point += delta; }
   void rotate(const Vec3 &axis, double angle) override;
+  ShapeType shape_type() const override { return ShapeType::Plane; }
 };
 
 } // namespace rt

--- a/include/rt/Sphere.hpp
+++ b/include/rt/Sphere.hpp
@@ -15,6 +15,7 @@ struct Sphere : public Hittable
            HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override;
   void translate(const Vec3 &delta) override { center += delta; }
+  ShapeType shape_type() const override { return ShapeType::Sphere; }
 };
 
 } // namespace rt

--- a/src/BVH.cpp
+++ b/src/BVH.cpp
@@ -69,6 +69,40 @@ bool BVHNode::bounding_box(AABB &out) const
   return true;
 }
 
+void BVHNode::query(const AABB &range, std::vector<HittablePtr> &out) const
+{
+  if (!box.intersects(range))
+  {
+    return;
+  }
+
+  if (left->is_bvh())
+  {
+    static_cast<BVHNode const *>(left.get())->query(range, out);
+  }
+  else
+  {
+    AABB lbox;
+    if (left->bounding_box(lbox) && lbox.intersects(range))
+    {
+      out.push_back(left);
+    }
+  }
+
+  if (right->is_bvh())
+  {
+    static_cast<BVHNode const *>(right.get())->query(range, out);
+  }
+  else
+  {
+    AABB rbox;
+    if (right->bounding_box(rbox) && rbox.intersects(range))
+    {
+      out.push_back(right);
+    }
+  }
+}
+
 int BVHNode::choose_axis(std::vector<HittablePtr> &objs, size_t start,
                          size_t end)
 {


### PR DESCRIPTION
## Summary
- add shape type system and BVH query to collect overlapping AABBs
- implement collision module with analytic checks and GJK fallback
- use BVH broad-phase in Scene::collides and reserve vectors to reduce allocations

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68b49536432c832f8e1d801be862690f