### PR TITLE
Ignore beams during collision checks

### DIFF
--- a/src/Collision.cpp
+++ b/src/Collision.cpp
@@ -266,6 +266,9 @@ bool precise_collision(const HittablePtr &a, const HittablePtr &b)
   if (!a || !b)
     return false;
 
+  if (a->is_beam() || b->is_beam())
+    return false;
+
   ShapeType ta = a->shape_type();
   ShapeType tb = b->shape_type();
 

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -133,17 +133,22 @@ bool Scene::collides(int index) const
   if (accel && accel->is_bvh())
   {
     static_cast<BVHNode const *>(accel.get())->query(box, candidates);
+    candidates.erase(std::remove_if(candidates.begin(), candidates.end(),
+                                    [](const HittablePtr &h) {
+                                      return h->is_beam();
+                                    }),
+                     candidates.end());
   }
   else
   {
     for (auto &o : objects)
-      if (!o->is_plane())
+      if (!o->is_plane() && !o->is_beam())
         candidates.push_back(o);
   }
 
   for (auto &cand : candidates)
   {
-    if (cand.get() == obj.get())
+    if (cand.get() == obj.get() || cand->is_beam())
       continue;
     if (precise_collision(obj, cand))
       return true;


### PR DESCRIPTION
## Summary
- exclude beams from collision queries to avoid treating them as physical objects
- early-return from precise collision if either shape is a beam

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`

------
https://chatgpt.com/codex/tasks/task_e_68b4a91f6548832f928179168eccf4d3