### PR TITLE
Implement camera collision with opaque objects

### DIFF
--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -2,6 +2,7 @@
 #pragma once
 #include "BVH.hpp"
 #include "Hittable.hpp"
+#include "Camera.hpp"
 #include "light.hpp"
 #include "material.hpp"
 #include <memory>
@@ -21,6 +22,8 @@ struct Scene
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
   bool collides(int index) const;
   Vec3 move_with_collision(int index, const Vec3 &delta);
+  Vec3 move_camera(Camera &cam, const Vec3 &delta,
+                   const std::vector<Material> &mats);
 };
 
 } // namespace rt

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -393,7 +393,7 @@ void Renderer::render_window(std::vector<Material> &mats,
         }
         else if (focused)
         {
-          cam.move(cam.up * step);
+          scene.move_camera(cam, cam.up * step, mats);
         }
       }
       else if (focused && e.type == SDL_KEYDOWN &&
@@ -412,17 +412,17 @@ void Renderer::render_window(std::vector<Material> &mats,
     {
       double cam_speed = CAMERA_MOVE_SPEED * dt;
       if (state[SDL_SCANCODE_W])
-        cam.move(forward_xz * cam_speed);
+        scene.move_camera(cam, forward_xz * cam_speed, mats);
       if (state[SDL_SCANCODE_S])
-        cam.move(forward_xz * -cam_speed);
+        scene.move_camera(cam, forward_xz * -cam_speed, mats);
       if (state[SDL_SCANCODE_A])
-        cam.move(right_xz * -cam_speed);
+        scene.move_camera(cam, right_xz * -cam_speed, mats);
       if (state[SDL_SCANCODE_D])
-        cam.move(right_xz * cam_speed);
+        scene.move_camera(cam, right_xz * cam_speed, mats);
       if (state[SDL_SCANCODE_SPACE])
-        cam.move(Vec3(0, 1, 0) * cam_speed);
+        scene.move_camera(cam, Vec3(0, 1, 0) * cam_speed, mats);
       if (state[SDL_SCANCODE_LCTRL])
-        cam.move(Vec3(0, -1, 0) * cam_speed);
+        scene.move_camera(cam, Vec3(0, -1, 0) * cam_speed, mats);
 
       double rot_speed = OBJECT_ROTATE_SPEED * dt;
       bool changed = false;
@@ -454,17 +454,17 @@ void Renderer::render_window(std::vector<Material> &mats,
         running = false;
       double speed = CAMERA_MOVE_SPEED * dt;
       if (state[SDL_SCANCODE_W])
-        cam.move(forward_xz * speed);
+        scene.move_camera(cam, forward_xz * speed, mats);
       if (state[SDL_SCANCODE_S])
-        cam.move(forward_xz * -speed);
+        scene.move_camera(cam, forward_xz * -speed, mats);
       if (state[SDL_SCANCODE_A])
-        cam.move(right_xz * -speed);
+        scene.move_camera(cam, right_xz * -speed, mats);
       if (state[SDL_SCANCODE_D])
-        cam.move(right_xz * speed);
+        scene.move_camera(cam, right_xz * speed, mats);
       if (state[SDL_SCANCODE_SPACE])
-        cam.move(Vec3(0, 1, 0) * speed);
+        scene.move_camera(cam, Vec3(0, 1, 0) * speed, mats);
       if (state[SDL_SCANCODE_LCTRL])
-        cam.move(Vec3(0, -1, 0) * speed);
+        scene.move_camera(cam, Vec3(0, -1, 0) * speed, mats);
     }
 
     if (edit_mode)


### PR DESCRIPTION
## Summary
- Prevent camera from passing through opaque scene geometry
- Add scene-level helper that ignores transparent materials when testing collisions
- Route all camera movement through new collision-aware routine

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_68b561e55dc8832fadc13d9fdeb4bffa