### PR TITLE
Add camera-object collision handling

### DIFF
--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -21,6 +21,8 @@ struct Scene
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
   bool collides(int index) const;
   Vec3 move_with_collision(int index, const Vec3 &delta);
+  Vec3 move_camera_with_collision(const Vec3 &pos, const Vec3 &delta,
+                                  const std::vector<Material> &mats) const;
 };
 
 } // namespace rt

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -393,7 +393,7 @@ void Renderer::render_window(std::vector<Material> &mats,
         }
         else if (focused)
         {
-          cam.move(cam.up * step);
+          cam.move(scene.move_camera_with_collision(cam.origin, cam.up * step, mats));
         }
       }
       else if (focused && e.type == SDL_KEYDOWN &&
@@ -412,17 +412,17 @@ void Renderer::render_window(std::vector<Material> &mats,
     {
       double cam_speed = CAMERA_MOVE_SPEED * dt;
       if (state[SDL_SCANCODE_W])
-        cam.move(forward_xz * cam_speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, forward_xz * cam_speed, mats));
       if (state[SDL_SCANCODE_S])
-        cam.move(forward_xz * -cam_speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, forward_xz * -cam_speed, mats));
       if (state[SDL_SCANCODE_A])
-        cam.move(right_xz * -cam_speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, right_xz * -cam_speed, mats));
       if (state[SDL_SCANCODE_D])
-        cam.move(right_xz * cam_speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, right_xz * cam_speed, mats));
       if (state[SDL_SCANCODE_SPACE])
-        cam.move(Vec3(0, 1, 0) * cam_speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, Vec3(0, 1, 0) * cam_speed, mats));
       if (state[SDL_SCANCODE_LCTRL])
-        cam.move(Vec3(0, -1, 0) * cam_speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, Vec3(0, -1, 0) * cam_speed, mats));
 
       double rot_speed = OBJECT_ROTATE_SPEED * dt;
       bool changed = false;
@@ -454,17 +454,17 @@ void Renderer::render_window(std::vector<Material> &mats,
         running = false;
       double speed = CAMERA_MOVE_SPEED * dt;
       if (state[SDL_SCANCODE_W])
-        cam.move(forward_xz * speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, forward_xz * speed, mats));
       if (state[SDL_SCANCODE_S])
-        cam.move(forward_xz * -speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, forward_xz * -speed, mats));
       if (state[SDL_SCANCODE_A])
-        cam.move(right_xz * -speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, right_xz * -speed, mats));
       if (state[SDL_SCANCODE_D])
-        cam.move(right_xz * speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, right_xz * speed, mats));
       if (state[SDL_SCANCODE_SPACE])
-        cam.move(Vec3(0, 1, 0) * speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, Vec3(0, 1, 0) * speed, mats));
       if (state[SDL_SCANCODE_LCTRL])
-        cam.move(Vec3(0, -1, 0) * speed);
+        cam.move(scene.move_camera_with_collision(cam.origin, Vec3(0, -1, 0) * speed, mats));
     }
 
     if (edit_mode)

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -194,6 +194,29 @@ bool Scene::collides(int index) const
   return false;
 }
 
+Vec3 Scene::move_camera_with_collision(const Vec3 &pos, const Vec3 &delta,
+                                       const std::vector<Material> &mats) const
+{
+  if (delta.length_squared() == 0)
+    return Vec3(0, 0, 0);
+  Vec3 dir = delta.normalized();
+  double len = delta.length();
+  Ray r(pos, dir);
+  double tmin = 1e-4;
+  HitRecord rec;
+  while (hit(r, tmin, len, rec))
+  {
+    auto obj = objects[rec.object_id];
+    if (!obj->is_beam() && mats[rec.material_id].alpha >= 1.0)
+    {
+      double allowed = std::max(0.0, rec.t - 1e-4);
+      return dir * allowed;
+    }
+    tmin = rec.t + 1e-4;
+  }
+  return delta;
+}
+
 bool Scene::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
   bool hit_any = false;


### PR DESCRIPTION
## Summary
- Add Scene::move_camera_with_collision to restrict camera movement to outside opaque objects
- Use new collision checks for mouse wheel and WASD camera motions

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b561e55dc8832fadc13d9fdeb4bffa