### PR TITLE
Add camera collision handling

### DIFF
--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -9,6 +9,7 @@
 
 namespace rt
 {
+struct Camera;
 struct Scene
 {
   std::vector<HittablePtr> objects;
@@ -21,6 +22,8 @@ struct Scene
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
   bool collides(int index) const;
   Vec3 move_with_collision(int index, const Vec3 &delta);
+  Vec3 move_camera(Camera &cam, const Vec3 &delta,
+                   const std::vector<Material> &mats) const;
 };
 
 } // namespace rt

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -393,7 +393,7 @@ void Renderer::render_window(std::vector<Material> &mats,
         }
         else if (focused)
         {
-          cam.move(cam.up * step);
+          scene.move_camera(cam, cam.up * step, mats);
         }
       }
       else if (focused && e.type == SDL_KEYDOWN &&
@@ -412,17 +412,17 @@ void Renderer::render_window(std::vector<Material> &mats,
     {
       double cam_speed = CAMERA_MOVE_SPEED * dt;
       if (state[SDL_SCANCODE_W])
-        cam.move(forward_xz * cam_speed);
+        scene.move_camera(cam, forward_xz * cam_speed, mats);
       if (state[SDL_SCANCODE_S])
-        cam.move(forward_xz * -cam_speed);
+        scene.move_camera(cam, forward_xz * -cam_speed, mats);
       if (state[SDL_SCANCODE_A])
-        cam.move(right_xz * -cam_speed);
+        scene.move_camera(cam, right_xz * -cam_speed, mats);
       if (state[SDL_SCANCODE_D])
-        cam.move(right_xz * cam_speed);
+        scene.move_camera(cam, right_xz * cam_speed, mats);
       if (state[SDL_SCANCODE_SPACE])
-        cam.move(Vec3(0, 1, 0) * cam_speed);
+        scene.move_camera(cam, Vec3(0, 1, 0) * cam_speed, mats);
       if (state[SDL_SCANCODE_LCTRL])
-        cam.move(Vec3(0, -1, 0) * cam_speed);
+        scene.move_camera(cam, Vec3(0, -1, 0) * cam_speed, mats);
 
       double rot_speed = OBJECT_ROTATE_SPEED * dt;
       bool changed = false;
@@ -454,17 +454,17 @@ void Renderer::render_window(std::vector<Material> &mats,
         running = false;
       double speed = CAMERA_MOVE_SPEED * dt;
       if (state[SDL_SCANCODE_W])
-        cam.move(forward_xz * speed);
+        scene.move_camera(cam, forward_xz * speed, mats);
       if (state[SDL_SCANCODE_S])
-        cam.move(forward_xz * -speed);
+        scene.move_camera(cam, forward_xz * -speed, mats);
       if (state[SDL_SCANCODE_A])
-        cam.move(right_xz * -speed);
+        scene.move_camera(cam, right_xz * -speed, mats);
       if (state[SDL_SCANCODE_D])
-        cam.move(right_xz * speed);
+        scene.move_camera(cam, right_xz * speed, mats);
       if (state[SDL_SCANCODE_SPACE])
-        cam.move(Vec3(0, 1, 0) * speed);
+        scene.move_camera(cam, Vec3(0, 1, 0) * speed, mats);
       if (state[SDL_SCANCODE_LCTRL])
-        cam.move(Vec3(0, -1, 0) * speed);
+        scene.move_camera(cam, Vec3(0, -1, 0) * speed, mats);
     }
 
     if (edit_mode)


### PR DESCRIPTION
## Summary
- block camera movement when opaque objects obstruct path
- skip collisions for transparent objects
- update renderer to use collision-aware camera movement

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b561e55dc8832fadc13d9fdeb4bffa