### PR TITLE
Align object rotations with camera axes

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -352,12 +352,12 @@ void Renderer::render_window(std::vector<Material> &mats,
         {
           double sens = MOUSE_SENSITIVITY;
           bool changed = false;
-          double yaw = -e.motion.xrel * sens;
-          if (yaw != 0.0)
+          double roll = -e.motion.xrel * sens;
+          if (roll != 0.0)
           {
-            scene.objects[selected_obj]->rotate(cam.up, yaw);
+            scene.objects[selected_obj]->rotate(cam.forward, roll);
             if (scene.collides(selected_obj))
-              scene.objects[selected_obj]->rotate(cam.up, -yaw);
+              scene.objects[selected_obj]->rotate(cam.forward, -roll);
             else
               changed = true;
           }
@@ -428,17 +428,17 @@ void Renderer::render_window(std::vector<Material> &mats,
       bool changed = false;
       if (state[SDL_SCANCODE_Q])
       {
-        scene.objects[selected_obj]->rotate(cam.forward, -rot_speed);
+        scene.objects[selected_obj]->rotate(cam.up, -rot_speed);
         if (scene.collides(selected_obj))
-          scene.objects[selected_obj]->rotate(cam.forward, rot_speed);
+          scene.objects[selected_obj]->rotate(cam.up, rot_speed);
         else
           changed = true;
       }
       if (state[SDL_SCANCODE_E])
       {
-        scene.objects[selected_obj]->rotate(cam.forward, rot_speed);
+        scene.objects[selected_obj]->rotate(cam.up, rot_speed);
         if (scene.collides(selected_obj))
-          scene.objects[selected_obj]->rotate(cam.forward, -rot_speed);
+          scene.objects[selected_obj]->rotate(cam.up, -rot_speed);
         else
           changed = true;
       }


### PR DESCRIPTION
## Summary
- rotate objects around view-aligned axes so mouse X rotates around Z (camera forward), mouse Y rotates around X (camera right), and Q/E keys spin around Y (camera up)

## Testing
- `cmake .. && cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68b56aec3d64832f9829cae7de9070d6