### PR TITLE
Add center screen crosshair

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -634,6 +634,10 @@ void Renderer::render_window(std::vector<Material> &mats,
       }
     }
     SDL_SetRenderDrawColor(ren, 255, 255, 255, 255);
+    int cx = W / 2;
+    int cy = H / 2;
+    SDL_RenderDrawLine(ren, cx - 10, cy, cx + 10, cy);
+    SDL_RenderDrawLine(ren, cx, cy - 10, cx, cy + 10);
     draw_text(ren, edit_mode ? "EDIT" : "SPECTATOR", 5, 5, 2);
     SDL_RenderPresent(ren);
   }


### PR DESCRIPTION
## Summary
- render a simple plus-shaped crosshair at the center of the window

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b57663c098832f952a7a0c1da4dbf0