### PR TITLE
Add map saving with 'C' key

### DIFF
--- a/include/rt/Parser.hpp
+++ b/include/rt/Parser.hpp
@@ -16,6 +16,10 @@ public:
 
   static const std::vector<Material> &get_materials();
 
+  static bool write_rt_file(const std::string &path, const Scene &scene,
+                            const Camera &cam,
+                            const std::vector<Material> &mats);
+
 private:
   // TO JEST KLUCZOWE: deklaracja storage'u
   static std::vector<Material> materials;

--- a/include/rt/Renderer.hpp
+++ b/include/rt/Renderer.hpp
@@ -19,7 +19,7 @@ struct RenderSettings
 class Renderer
 {
 public:
-  Renderer(Scene &s, Camera &c);
+  Renderer(Scene &s, Camera &c, const std::string &scene_path);
   void render_ppm(const std::string &path, const std::vector<Material> &mats,
                   const RenderSettings &rset);
   void render_window(std::vector<Material> &mats,
@@ -28,6 +28,9 @@ public:
 private:
   Scene &scene;
   Camera &cam;
+  std::string base_path;
+  int save_counter = 0;
+  void save_scene(const std::vector<Material> &mats);
 };
 
 } // namespace rt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
   rset.threads = threads;
   rset.downscale = downscale;
 
-  rt::Renderer renderer(scene, cam);
+  rt::Renderer renderer(scene, cam, scene_path);
   renderer.render_window(mats, rset);
 
   return 0;


### PR DESCRIPTION
## Summary
- Save the current scene to numbered `.rt` files when pressing the `C` key
- Serialize scenes via new `Parser::write_rt_file`
- Track base scene path and save counter inside `Renderer`

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b57642b750832fb09f4bb9801adfa0