### PR TITLE
Add scene saving with C key

### DIFF
--- a/include/rt/Parser.hpp
+++ b/include/rt/Parser.hpp
@@ -14,6 +14,10 @@ public:
   static bool parse_rt_file(const std::string &path, Scene &outScene,
                             Camera &outCamera, int width, int height);
 
+  static bool save_rt_file(const std::string &path, const Scene &scene,
+                           const Camera &cam,
+                           const std::vector<Material> &mats);
+
   static const std::vector<Material> &get_materials();
 
 private:

--- a/include/rt/Renderer.hpp
+++ b/include/rt/Renderer.hpp
@@ -23,7 +23,8 @@ public:
   void render_ppm(const std::string &path, const std::vector<Material> &mats,
                   const RenderSettings &rset);
   void render_window(std::vector<Material> &mats,
-                     const RenderSettings &rset);
+                     const RenderSettings &rset,
+                     const std::string &scene_path);
 
 private:
   Scene &scene;

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <string_view>
 #include <cstring>
+#include <iomanip>
 
 namespace
 {
@@ -117,6 +118,8 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
   std::ifstream in(path);
   if (!in)
     return false;
+
+  materials.clear();
 
   std::string line;
   int oid = 0, mid = 0;
@@ -325,6 +328,138 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
 
   outCamera =
       Camera(cam_pos, cam_pos + cam_dir, fov, double(width) / double(height));
+
+  outScene.update_beams(materials);
+
+  return true;
+}
+
+bool Parser::save_rt_file(const std::string &path, const Scene &scene,
+                          const Camera &cam,
+                          const std::vector<Material> &mats)
+{
+  std::ofstream out(path);
+  if (!out)
+    return false;
+  out << std::fixed << std::setprecision(5);
+
+  auto write_vec = [&](const Vec3 &v) { out << v.x << "," << v.y << "," << v.z; };
+
+  auto write_rgba = [&](const Vec3 &col, double alpha)
+  {
+    auto clamp01 = [](double x) { return std::clamp(x, 0.0, 1.0); };
+    int r = static_cast<int>(std::lround(clamp01(col.x) * 255.0));
+    int g = static_cast<int>(std::lround(clamp01(col.y) * 255.0));
+    int b = static_cast<int>(std::lround(clamp01(col.z) * 255.0));
+    int a = static_cast<int>(std::lround(clamp01(alpha) * 255.0));
+    out << r << "," << g << "," << b << "," << a;
+  };
+
+  // Ambient
+  out << "A " << scene.ambient.intensity << " ";
+  write_rgba(scene.ambient.color, 1.0);
+  out << "\n";
+
+  // Camera
+  out << "C ";
+  write_vec(cam.origin);
+  out << " ";
+  write_vec(cam.forward);
+  out << " " << cam.fov_deg << "\n";
+
+  // Lights
+  for (const auto &L : scene.lights)
+  {
+    out << "L ";
+    write_vec(L.position);
+    out << " " << L.intensity << " ";
+    write_rgba(L.color, 1.0);
+    out << "\n";
+  }
+
+  // Objects
+  for (const auto &obj : scene.objects)
+  {
+    const Material &m = mats[obj->material_id];
+    std::string mirror = m.mirror ? "R" : "NR";
+    std::string move = obj->movable ? "M" : "IM";
+    switch (obj->shape_type())
+    {
+    case ShapeType::Sphere:
+    {
+      const Sphere *s = static_cast<const Sphere *>(obj.get());
+      out << "sp ";
+      write_vec(s->center);
+      out << " " << s->radius << " ";
+      write_rgba(m.base_color, m.alpha);
+      out << " " << mirror << " " << move << "\n";
+      break;
+    }
+    case ShapeType::Plane:
+    {
+      const Plane *pl = static_cast<const Plane *>(obj.get());
+      out << "pl ";
+      write_vec(pl->point);
+      out << " ";
+      write_vec(pl->normal);
+      out << " ";
+      write_rgba(m.base_color, m.alpha);
+      out << " " << mirror << " " << move << "\n";
+      break;
+    }
+    case ShapeType::Cylinder:
+    {
+      const Cylinder *cy = static_cast<const Cylinder *>(obj.get());
+      out << "cy ";
+      write_vec(cy->center);
+      out << " ";
+      write_vec(cy->axis);
+      out << " " << cy->radius * 2.0 << " " << cy->height << " ";
+      write_rgba(m.base_color, m.alpha);
+      out << " " << mirror << " " << move << "\n";
+      break;
+    }
+    case ShapeType::Cone:
+    {
+      const Cone *co = static_cast<const Cone *>(obj.get());
+      out << "co ";
+      write_vec(co->center);
+      out << " ";
+      write_vec(co->axis);
+      out << " " << co->radius * 2.0 << " " << co->height << " ";
+      write_rgba(m.base_color, m.alpha);
+      out << " " << mirror << " " << move << "\n";
+      break;
+    }
+    case ShapeType::Cube:
+    {
+      const Cube *cu = static_cast<const Cube *>(obj.get());
+      out << "cu ";
+      write_vec(cu->center);
+      out << " " << cu->half * 2.0 << " ";
+      write_rgba(m.base_color, m.alpha);
+      out << " " << mirror << " " << move << "\n";
+      break;
+    }
+    case ShapeType::Beam:
+    {
+      const Beam *bm = static_cast<const Beam *>(obj.get());
+      if (bm->start > 0.0)
+        continue;
+      out << "bm ";
+      write_vec(bm->path.orig);
+      out << " ";
+      write_vec(bm->path.dir);
+      out << " ";
+      write_rgba(m.base_color, m.alpha);
+      out << " " << bm->radius << " " << bm->total_length << "\n";
+      break;
+    }
+    default:
+      break;
+    }
+  }
+
   return true;
 }
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,6 +1,7 @@
 #include "rt/Renderer.hpp"
 #include "rt/Config.hpp"
 #include "rt/AABB.hpp"
+#include "rt/Parser.hpp"
 #include <SDL.h>
 #include <algorithm>
 #include <atomic>
@@ -11,6 +12,8 @@
 #include <string>
 #include <random>
 #include <thread>
+#include <filesystem>
+#include <cctype>
 
 namespace rt
 {
@@ -203,7 +206,8 @@ void Renderer::render_ppm(const std::string &path,
 }
 
 void Renderer::render_window(std::vector<Material> &mats,
-                             const RenderSettings &rset)
+                             const RenderSettings &rset,
+                             const std::string &scene_path)
 {
   const int W = rset.width;
   const int H = rset.height;
@@ -215,6 +219,25 @@ void Renderer::render_window(std::vector<Material> &mats,
                     : (std::thread::hardware_concurrency()
                            ? (int)std::thread::hardware_concurrency()
                            : 8);
+
+  std::filesystem::path base(scene_path);
+  std::filesystem::path dir = base.parent_path();
+  std::string stem = base.stem().string();
+  std::string ext = base.extension().string();
+  int save_id = 0;
+  auto pos = stem.rfind('_');
+  if (pos != std::string::npos)
+  {
+    std::string idpart = stem.substr(pos + 1);
+    if (!idpart.empty() &&
+        std::all_of(idpart.begin(), idpart.end(), [](char c) {
+          return std::isdigit(static_cast<unsigned char>(c));
+        }))
+    {
+      save_id = std::stoi(idpart);
+      stem = stem.substr(0, pos);
+    }
+  }
 
   if (SDL_Init(SDL_INIT_VIDEO) != 0)
   {
@@ -395,6 +418,18 @@ void Renderer::render_window(std::vector<Material> &mats,
         {
           scene.move_camera(cam, cam.up * step, mats);
         }
+      }
+      else if (focused && e.type == SDL_KEYDOWN &&
+               e.key.keysym.scancode == SDL_SCANCODE_C)
+      {
+        scene.update_beams(mats);
+        ++save_id;
+        std::filesystem::path outp =
+            dir / (stem + "_" + std::to_string(save_id) + ext);
+        if (Parser::save_rt_file(outp.string(), scene, cam, mats))
+          std::cout << "Saved scene to " << outp.string() << "\n";
+        else
+          std::cerr << "Failed to save scene to " << outp.string() << "\n";
       }
       else if (focused && e.type == SDL_KEYDOWN &&
                e.key.keysym.scancode == SDL_SCANCODE_ESCAPE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,7 +52,6 @@ int main(int argc, char **argv)
     return 2;
   }
   auto mats = rt::Parser::get_materials();
-  scene.update_beams(mats);
   scene.build_bvh();
 
   rt::RenderSettings rset;
@@ -62,7 +61,7 @@ int main(int argc, char **argv)
   rset.downscale = downscale;
 
   rt::Renderer renderer(scene, cam);
-  renderer.render_window(mats, rset);
+  renderer.render_window(mats, rset, scene_path);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- Recompute beam reflections when loading `.rt` scenes so beams react to moved objects
- Save scenes with incrementing `_id` suffixes, replacing any existing id to avoid `map_1_1.rt`
- Recalculate beams before each save so only valid sources are serialized

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b57642b750832fb09f4bb9801adfa0