### PR TITLE
Add light at beam source with occlusion ignore

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "Beam.hpp"
 #include "Sphere.hpp"
+#include "light.hpp"
 #include <memory>
 
 namespace rt
@@ -10,6 +11,7 @@ struct BeamSource : public Sphere
   Sphere mid;
   Sphere inner;
   std::shared_ptr<Beam> beam;
+  PointLight *light = nullptr;
   BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Beam> &bm,
              int oid, int mat_big, int mat_mid, int mat_small);
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;

--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -9,8 +9,9 @@ struct PointLight
   Vec3 position;
   Vec3 color;
   double intensity;
+  int ignore_id;
 
-  PointLight(const Vec3 &p, const Vec3 &c, double i);
+  PointLight(const Vec3 &p, const Vec3 &c, double i, int ignore = -1);
 };
 
 struct Ambient

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -47,6 +47,8 @@ void BeamSource::translate(const Vec3 &delta)
   inner.translate(delta);
   if (beam)
     beam->path.orig += delta;
+  if (light)
+    light->position += delta;
 }
 
 void BeamSource::rotate(const Vec3 &ax, double angle)

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -322,6 +322,9 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
+
+        outScene.lights.emplace_back(o, unit, 0.75, src->object_id);
+        src->light = &outScene.lights.back();
       }
     }
     else if (id == "co")

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -23,7 +23,7 @@ static bool in_shadow(const Scene &scene, const Vec3 &p, const PointLight &L)
   HitRecord tmp;
   for (const auto &obj : scene.objects)
   {
-    if (obj->is_beam())
+    if (obj->is_beam() || obj->object_id == L.ignore_id)
       continue;
     if (obj->hit(shadow_ray, 1e-4, dist_to_light - 1e-4, tmp))
     {

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -2,8 +2,8 @@
 
 namespace rt
 {
-PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i)
-    : position(p), color(c), intensity(i)
+PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i, int ignore)
+    : position(p), color(c), intensity(i), ignore_id(ignore)
 {
 }
 


### PR DESCRIPTION
## Summary
- Add ignoreable PointLight and beam-source-attached light
- Skip beam source when checking shadows
- Spawn beam lights from scene parser

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b5981aafcc832faf567d5d9aa607eb