### PR TITLE
Add internal light source for beam sources

### DIFF
--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -4,13 +4,19 @@
 
 namespace rt
 {
+struct Hittable;
+
 struct PointLight
 {
   Vec3 position;
   Vec3 color;
   double intensity;
+  const Hittable *ignore1;
+  const Hittable *ignore2;
 
-  PointLight(const Vec3 &p, const Vec3 &c, double i);
+  PointLight(const Vec3 &p, const Vec3 &c, double i,
+             const Hittable *ig1 = nullptr,
+             const Hittable *ig2 = nullptr);
 };
 
 struct Ambient

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -322,6 +322,7 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
+        outScene.lights.emplace_back(o, unit, 0.75, bm.get(), src.get());
       }
     }
     else if (id == "co")

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -25,6 +25,8 @@ static bool in_shadow(const Scene &scene, const Vec3 &p, const PointLight &L)
   {
     if (obj->is_beam())
       continue;
+    if (obj.get() == L.ignore1 || obj.get() == L.ignore2)
+      continue;
     if (obj->hit(shadow_ray, 1e-4, dist_to_light - 1e-4, tmp))
     {
       return true;
@@ -62,6 +64,10 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
            col.z * scene.ambient.color.z * scene.ambient.intensity);
   for (const auto &L : scene.lights)
   {
+    int id1 = L.ignore1 ? L.ignore1->object_id : -1;
+    int id2 = L.ignore2 ? L.ignore2->object_id : -1;
+    if (rec.object_id == id1 || rec.object_id == id2)
+      continue;
     if (in_shadow(scene, rec.p, L))
       continue;
     Vec3 ldir = (L.position - rec.p).normalized();

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -2,8 +2,9 @@
 
 namespace rt
 {
-PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i)
-    : position(p), color(c), intensity(i)
+PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
+                       const Hittable *ig1, const Hittable *ig2)
+    : position(p), color(c), intensity(i), ignore1(ig1), ignore2(ig2)
 {
 }
 


### PR DESCRIPTION
## Summary
- add point light at beam source center with beam color
- ensure light ignores its beam and source geometry for shading and shadows

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b5981aafcc832faf567d5d9aa607eb