### PR TITLE
Add map save functionality with incremental filenames

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -17,5 +17,6 @@ struct BeamSource : public Sphere
   void translate(const Vec3 &delta) override;
   void rotate(const Vec3 &axis, double angle) override;
   Vec3 spot_direction() const override;
+  bool is_beam_source() const override { return true; }
 };
 } // namespace rt

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -45,6 +45,7 @@ struct Hittable
   virtual bool bounding_box(AABB &out) const = 0;
   virtual ShapeType shape_type() const { return ShapeType::Generic; }
   virtual bool is_beam() const { return false; }
+  virtual bool is_beam_source() const { return false; }
   virtual bool is_plane() const { return false; }
   virtual bool is_bvh() const { return false; }
   // default translation does nothing

--- a/include/rt/Parser.hpp
+++ b/include/rt/Parser.hpp
@@ -14,6 +14,10 @@ public:
   static bool parse_rt_file(const std::string &path, Scene &outScene,
                             Camera &outCamera, int width, int height);
 
+  static bool write_rt_file(const std::string &path, const Scene &scene,
+                            const Camera &cam,
+                            const std::vector<Material> &mats);
+
   static const std::vector<Material> &get_materials();
 
 private:

--- a/include/rt/Renderer.hpp
+++ b/include/rt/Renderer.hpp
@@ -23,7 +23,8 @@ public:
   void render_ppm(const std::string &path, const std::vector<Material> &mats,
                   const RenderSettings &rset);
   void render_window(std::vector<Material> &mats,
-                     const RenderSettings &rset);
+                     const RenderSettings &rset,
+                     const std::string &scene_path);
 
 private:
   Scene &scene;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
   rset.downscale = downscale;
 
   rt::Renderer renderer(scene, cam);
-  renderer.render_window(mats, rset);
+  renderer.render_window(mats, rset, scene_path);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- Implement scene serialization to `.rt` via `Parser::write_rt_file`
- Add keyboard shortcut `C` to save current map with incremental numbering
- Expose beam sources through new `is_beam_source` flag to avoid saving reflections

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b5b0c82414832f97b4ed2366846dd0