### PR TITLE
Add interactive map saving with incremental filenames

### DIFF
--- a/include/rt/Parser.hpp
+++ b/include/rt/Parser.hpp
@@ -15,6 +15,9 @@ public:
                             Camera &outCamera, int width, int height);
 
   static const std::vector<Material> &get_materials();
+  static bool save_rt_file(const std::string &path, const Scene &scene,
+                           const Camera &cam,
+                           const std::vector<Material> &mats);
 
 private:
   // TO JEST KLUCZOWE: deklaracja storage'u

--- a/include/rt/Renderer.hpp
+++ b/include/rt/Renderer.hpp
@@ -23,7 +23,8 @@ public:
   void render_ppm(const std::string &path, const std::vector<Material> &mats,
                   const RenderSettings &rset);
   void render_window(std::vector<Material> &mats,
-                     const RenderSettings &rset);
+                     const RenderSettings &rset,
+                     const std::string &scene_path);
 
 private:
   Scene &scene;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
   rset.downscale = downscale;
 
   rt::Renderer renderer(scene, cam);
-  renderer.render_window(mats, rset);
+  renderer.render_window(mats, rset, scene_path);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- Save current scene to a new `.rt` file when pressing **C**
- Name saved files with incrementing numeric suffixes based on current scene
- Serialize scene objects and original beam sources only

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b0c82414832f97b4ed2366846dd0