### PR TITLE
Enable beam light reflections

### DIFF
--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -10,12 +10,13 @@ struct PointLight
   Vec3 position;
   Vec3 color;
   double intensity;
+  double range;
   std::vector<int> ignore_ids;
   int attached_id;
   Vec3 direction;
   double cutoff_cos;
 
-  PointLight(const Vec3 &p, const Vec3 &c, double i,
+  PointLight(const Vec3 &p, const Vec3 &c, double i, double range = -1.0,
              std::vector<int> ignore_ids = {}, int attached_id = -1,
              const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
 };

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -325,7 +325,7 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         outScene.objects.push_back(src);
         const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
         outScene.lights.emplace_back(
-            o, unit, 0.75,
+            o, unit, 0.75, bm->length,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
             src->object_id, dir_norm, cone_cos);
       }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -69,6 +69,9 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
         L.ignore_ids.end())
       continue;
     Vec3 to_light = L.position - rec.p;
+    double dist2 = to_light.length_squared();
+    if (L.range > 0.0 && dist2 > L.range * L.range)
+      continue;
     Vec3 ldir = to_light.normalized();
     if (L.cutoff_cos > -1.0)
     {

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -128,6 +128,15 @@ void Scene::update_beams(const std::vector<Material> &mats)
       if (it != id_map.end())
         ign = it->second;
     }
+    for (int ign : L.ignore_ids)
+    {
+      if (ign >= 0 && ign < static_cast<int>(objects.size()) &&
+          objects[ign]->is_beam())
+      {
+        L.range = std::static_pointer_cast<Beam>(objects[ign])->length;
+        break;
+      }
+    }
   }
 
   const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
@@ -139,7 +148,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
     if (bm->start <= 0.0)
       continue;
     Vec3 col = mats[bm->material_id].color;
-    lights.emplace_back(bm->path.orig, col, 0.75,
+    lights.emplace_back(bm->path.orig, col, 0.75, bm->length,
                         std::vector<int>{bm->object_id}, REFLECTION_LIGHT,
                         bm->path.dir, cone_cos);
   }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -4,11 +4,14 @@
 #include "rt/Collision.hpp"
 #include "rt/Camera.hpp"
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <unordered_map>
 
 namespace
 {
+constexpr int REFLECTION_LIGHT = -2;
+
 inline rt::Vec3 reflect(const rt::Vec3 &v, const rt::Vec3 &n)
 {
   return v - n * (2.0 * rt::Vec3::dot(v, n));
@@ -24,6 +27,12 @@ void Scene::update_beams(const std::vector<Material> &mats)
   std::vector<HittablePtr> non_beams;
   non_beams.reserve(objects.size());
   std::unordered_map<int, int> id_map;
+
+  // Remove lights created for reflected beams from previous updates.
+  lights.erase(std::remove_if(lights.begin(), lights.end(),
+                              [](const PointLight &L)
+                              { return L.attached_id == REFLECTION_LIGHT; }),
+               lights.end());
 
   for (auto &obj : objects)
   {
@@ -119,6 +128,20 @@ void Scene::update_beams(const std::vector<Material> &mats)
       if (it != id_map.end())
         ign = it->second;
     }
+  }
+
+  const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+  for (const auto &obj : objects)
+  {
+    if (!obj->is_beam())
+      continue;
+    auto bm = std::static_pointer_cast<Beam>(obj);
+    if (bm->start <= 0.0)
+      continue;
+    Vec3 col = mats[bm->material_id].color;
+    lights.emplace_back(bm->path.orig, col, 0.75,
+                        std::vector<int>{bm->object_id}, REFLECTION_LIGHT,
+                        bm->path.dir, cone_cos);
   }
 }
 

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -3,10 +3,10 @@
 
 namespace rt
 {
-PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
+PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i, double r,
                        std::vector<int> ignore_ids, int attached_id,
                        const Vec3 &dir, double cutoff)
-    : position(p), color(c), intensity(i),
+    : position(p), color(c), intensity(i), range(r),
       ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
       direction(dir), cutoff_cos(cutoff)
 {}

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -24,7 +24,10 @@ Vec3 phong(const Material &m, const Ambient &ambient,
            col.z * ambient.color.z * ambient.intensity);
   for (const auto &L : lights)
   {
-    Vec3 ldir = (L.position - p).normalized();
+    Vec3 to_light = L.position - p;
+    if (L.range > 0.0 && to_light.length_squared() > L.range * L.range)
+      continue;
+    Vec3 ldir = to_light.normalized();
     if (L.cutoff_cos > -1.0)
     {
       Vec3 spot_dir = (p - L.position).normalized();


### PR DESCRIPTION
## Summary
- propagate beam lighting through reflective surfaces
- clean up and rebuild reflected beam lights every update

## Testing
- `apt-get install -y libsdl2-dev`
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b5b3083804832fa37535490d9358bf