### PR TITLE
Enable beam light reflections

### DIFF
--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -10,6 +10,7 @@ struct PointLight
   Vec3 position;
   Vec3 color;
   double intensity;
+  double range;
   std::vector<int> ignore_ids;
   int attached_id;
   Vec3 direction;
@@ -17,7 +18,8 @@ struct PointLight
 
   PointLight(const Vec3 &p, const Vec3 &c, double i,
              std::vector<int> ignore_ids = {}, int attached_id = -1,
-             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
+             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0,
+             double range = -1.0);
 };
 
 struct Ambient

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -327,7 +327,7 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         outScene.lights.emplace_back(
             o, unit, 0.75,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
-            src->object_id, dir_norm, cone_cos);
+            src->object_id, dir_norm, cone_cos, L);
       }
     }
     else if (id == "co")

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -17,9 +17,12 @@ namespace rt
 
 static bool in_shadow(const Scene &scene, const Vec3 &p, const PointLight &L)
 {
-  Vec3 dir = (L.position - p).normalized();
+  Vec3 to_light = L.position - p;
+  double dist_to_light = to_light.length();
+  if (L.range > 0.0 && dist_to_light > L.range)
+    dist_to_light = L.range;
+  Vec3 dir = to_light.normalized();
   Ray shadow_ray(p + dir * 1e-4, dir);
-  double dist_to_light = (L.position - p).length();
   HitRecord tmp;
   for (const auto &obj : scene.objects)
   {
@@ -69,7 +72,10 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
         L.ignore_ids.end())
       continue;
     Vec3 to_light = L.position - rec.p;
-    Vec3 ldir = to_light.normalized();
+    double dist_to_light = to_light.length();
+    if (L.range > 0.0 && dist_to_light > L.range)
+      continue;
+    Vec3 ldir = to_light / dist_to_light;
     if (L.cutoff_cos > -1.0)
     {
       Vec3 spot_dir = (rec.p - L.position).normalized();

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -4,11 +4,14 @@
 #include "rt/Collision.hpp"
 #include "rt/Camera.hpp"
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <unordered_map>
 
 namespace
 {
+constexpr int REFLECTION_LIGHT = -2;
+
 inline rt::Vec3 reflect(const rt::Vec3 &v, const rt::Vec3 &n)
 {
   return v - n * (2.0 * rt::Vec3::dot(v, n));
@@ -24,6 +27,12 @@ void Scene::update_beams(const std::vector<Material> &mats)
   std::vector<HittablePtr> non_beams;
   non_beams.reserve(objects.size());
   std::unordered_map<int, int> id_map;
+
+  // Remove lights created for reflected beams from previous updates.
+  lights.erase(std::remove_if(lights.begin(), lights.end(),
+                              [](const PointLight &L)
+                              { return L.attached_id == REFLECTION_LIGHT; }),
+               lights.end());
 
   for (auto &obj : objects)
   {
@@ -108,9 +117,32 @@ void Scene::update_beams(const std::vector<Material> &mats)
         L.attached_id = it->second;
       if (L.attached_id >= 0 && L.attached_id < static_cast<int>(objects.size()))
       {
-        Vec3 dir = objects[L.attached_id]->spot_direction();
+        auto obj = objects[L.attached_id];
+        Vec3 dir = obj->spot_direction();
         if (dir.length_squared() > 0)
           L.direction = dir.normalized();
+        if (obj->is_beam())
+        {
+          auto bm = std::static_pointer_cast<Beam>(obj);
+          L.range = bm->length;
+        }
+        else
+        {
+          for (const auto &o : objects)
+          {
+            if (!o->is_beam())
+              continue;
+            auto bm = std::static_pointer_cast<Beam>(o);
+            if (auto src = bm->source.lock())
+            {
+              if (src.get() == obj.get())
+              {
+                L.range = bm->length;
+                break;
+              }
+            }
+          }
+        }
       }
     }
     for (int &ign : L.ignore_ids)
@@ -119,6 +151,20 @@ void Scene::update_beams(const std::vector<Material> &mats)
       if (it != id_map.end())
         ign = it->second;
     }
+  }
+
+  const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+  for (const auto &obj : objects)
+  {
+    if (!obj->is_beam())
+      continue;
+    auto bm = std::static_pointer_cast<Beam>(obj);
+    if (bm->start <= 0.0)
+      continue;
+    Vec3 col = mats[bm->material_id].color;
+    lights.emplace_back(bm->path.orig, col, 0.75,
+                        std::vector<int>{bm->object_id}, REFLECTION_LIGHT,
+                        bm->path.dir, cone_cos, bm->length);
   }
 }
 

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -5,8 +5,8 @@ namespace rt
 {
 PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
                        std::vector<int> ignore_ids, int attached_id,
-                       const Vec3 &dir, double cutoff)
-    : position(p), color(c), intensity(i),
+                       const Vec3 &dir, double cutoff, double range)
+    : position(p), color(c), intensity(i), range(range),
       ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
       direction(dir), cutoff_cos(cutoff)
 {}

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -24,7 +24,11 @@ Vec3 phong(const Material &m, const Ambient &ambient,
            col.z * ambient.color.z * ambient.intensity);
   for (const auto &L : lights)
   {
-    Vec3 ldir = (L.position - p).normalized();
+    Vec3 to_light = L.position - p;
+    double dist = to_light.length();
+    if (L.range > 0.0 && dist > L.range)
+      continue;
+    Vec3 ldir = to_light / dist;
     if (L.cutoff_cos > -1.0)
     {
       Vec3 spot_dir = (p - L.position).normalized();


### PR DESCRIPTION
## Summary
- propagate beam lighting through reflective surfaces
- clean up and rebuild reflected beam lights every update
- clamp point light range to the length of its beam segment

## Testing
- `apt-get install -y libsdl2-dev`
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b5b3083804832fa37535490d9358bf