### PR TITLE
Reflective beam lights fade with distance

### DIFF
--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -10,12 +10,13 @@ struct PointLight
   Vec3 position;
   Vec3 color;
   double intensity;
+  double range;
   std::vector<int> ignore_ids;
   int attached_id;
   Vec3 direction;
   double cutoff_cos;
 
-  PointLight(const Vec3 &p, const Vec3 &c, double i,
+  PointLight(const Vec3 &p, const Vec3 &c, double i, double range = 1e9,
              std::vector<int> ignore_ids = {}, int attached_id = -1,
              const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
 };

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -33,7 +33,12 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
   {
     Vec3 beam_dir = beam ? beam->path.dir : Vec3(0, 0, 1);
     Vec3 to_hit = (tmp.p - inner.center).normalized();
-    const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    double ratio = 0.0;
+    if (beam && inner.radius > 0.0)
+      ratio = beam->radius / inner.radius;
+    if (ratio > 0.999)
+      ratio = 0.999;
+    const double hole_cos = std::sqrt(1.0 - ratio * ratio);
     if (Vec3::dot(beam_dir, to_hit) < hole_cos)
     {
       hit_any = true;

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -167,7 +167,7 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
       if (parse_triple(s_pos, p) && to_double(s_intens, inten) &&
           parse_rgba(s_rgb, rgb, a))
       {
-        outScene.lights.emplace_back(p, rgb_to_unit(rgb), inten);
+        outScene.lights.emplace_back(p, rgb_to_unit(rgb), inten, 1e9);
       }
     }
     else if (id == "sp")
@@ -326,11 +326,12 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
-        outScene.lights.emplace_back(
-            o, unit, 0.75,
-            std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
-            src->object_id, dir_norm, cone_cos);
+          const double cone_cos =
+              std::sqrt(std::max(0.0, 1.0 - g * g));
+          outScene.lights.emplace_back(
+              o, unit, 0.75, L,
+              std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
+              src->object_id, dir_norm, cone_cos);
       }
     }
     else if (id == "co")

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -3,10 +3,10 @@
 
 namespace rt
 {
-PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
+PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i, double rng,
                        std::vector<int> ignore_ids, int attached_id,
                        const Vec3 &dir, double cutoff)
-    : position(p), color(c), intensity(i),
+    : position(p), color(c), intensity(i), range(rng),
       ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
       direction(dir), cutoff_cos(cutoff)
 {}


### PR DESCRIPTION
## Summary
- Add range-aware point lights with linear attenuation
- Reflect beams spawn matching spotlights and update original beam light ranges
- Size beam-source hole to match beam diameter

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b5c0130a44832fbf5c65bde61b4f2e