### PR TITLE
Implement reflective light ray fading

### DIFF
--- a/include/rt/Beam.hpp
+++ b/include/rt/Beam.hpp
@@ -8,7 +8,8 @@ namespace rt
 struct Beam : public Hittable
 {
   Ray path;
-  double radius;
+  double radius;       // visual beam radius
+  double light_radius; // slightly larger radius for light effect
   double length;
   double start;
   double total_length;

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -31,6 +31,7 @@ struct HitRecord
   int material_id;
   bool front_face;
   double beam_ratio = 0.0;
+  double beam_radial = 0.0;
   void set_face_normal(const Ray &r, const Vec3 &outward_normal);
 };
 

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -6,7 +6,8 @@ namespace rt
 {
 Beam::Beam(const Vec3 &origin, const Vec3 &dir, double r, double len, int oid,
            int mid, double s, double total)
-    : path(origin, dir.normalized()), radius(r), length(len), start(s),
+    : path(origin, dir.normalized()), radius(r),
+      light_radius(r * 1.1), length(len), start(s),
       total_length(total < 0 ? len : total)
 {
   object_id = oid;
@@ -46,8 +47,10 @@ bool Beam::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
   Vec3 pb = path.at(tc);
   Vec3 diff = pr - pb;
   double dist2 = diff.length_squared();
-  if (dist2 > radius * radius)
+  if (dist2 > light_radius * light_radius)
     return false;
+  double dist_len = std::sqrt(dist2);
+  rec.beam_radial = dist_len / light_radius;
 
   Vec3 outward;
   if (dist2 > 1e-12)
@@ -79,7 +82,7 @@ bool Beam::bounding_box(AABB &out) const
            std::min(start.z, end.z));
   Vec3 max(std::max(start.x, end.x), std::max(start.y, end.y),
            std::max(start.z, end.z));
-  Vec3 ex(radius, radius, radius);
+  Vec3 ex(light_radius, light_radius, light_radius);
   out = AABB(min - ex, max + ex);
   return true;
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -44,6 +44,7 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
                       std::uniform_real_distribution<double> &dist,
                       int depth = 0)
 {
+  (void)dist;
   if (depth > 10)
     return Vec3(0.0, 0.0, 0.0);
   HitRecord rec;
@@ -102,8 +103,8 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
   if (m.random_alpha)
   {
     double tpos = std::clamp(rec.beam_ratio, 0.0, 1.0);
-    double rand = (1.0 - tpos) * std::pow(dist(rng), tpos);
-    alpha *= rand;
+    double radial = std::clamp(rec.beam_radial, 0.0, 1.0);
+    alpha *= (1.0 - tpos) * (1.0 - radial);
   }
   if (alpha < 1.0)
   {


### PR DESCRIPTION
## Summary
- Add radial tracking in `HitRecord` and widen beam with an outer light radius.
- Calculate radial hit distance in `Beam` to support a light aura that reflects with the beam.
- Fade beam opacity based on travel distance and radial distance for a gradual dim-to-dark effect.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b6e0db1a90832fbb1b949c1848c902