### PR TITLE
Add spotlight range and girth support

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -17,5 +17,7 @@ struct BeamSource : public Sphere
   void translate(const Vec3 &delta) override;
   void rotate(const Vec3 &axis, double angle) override;
   Vec3 spot_direction() const override;
+  double spot_range() const override;
+  double spot_girth() const override;
 };
 } // namespace rt

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -56,6 +56,8 @@ struct Hittable
     (void)angle;
   }
   virtual Vec3 spot_direction() const { return Vec3(0, 0, 0); }
+  virtual double spot_range() const { return -1.0; }
+  virtual double spot_girth() const { return -1.0; }
 };
 
 using HittablePtr = std::shared_ptr<Hittable>;

--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -14,10 +14,13 @@ struct PointLight
   int attached_id;
   Vec3 direction;
   double cutoff_cos;
+  double range;
+  double girth;
 
   PointLight(const Vec3 &p, const Vec3 &c, double i,
              std::vector<int> ignore_ids = {}, int attached_id = -1,
-             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
+             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0,
+             double range = -1.0, double girth = -1.0);
 };
 
 struct Ambient

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -69,4 +69,8 @@ Vec3 BeamSource::spot_direction() const
   return beam ? beam->path.dir : Vec3(0, 0, 1);
 }
 
+double BeamSource::spot_range() const { return beam ? beam->length : -1.0; }
+
+double BeamSource::spot_girth() const { return beam ? beam->radius : -1.0; }
+
 } // namespace rt

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -111,6 +111,12 @@ void Scene::update_beams(const std::vector<Material> &mats)
         Vec3 dir = objects[L.attached_id]->spot_direction();
         if (dir.length_squared() > 0)
           L.direction = dir.normalized();
+        double r = objects[L.attached_id]->spot_range();
+        if (r > 0.0)
+          L.range = r;
+        double g = objects[L.attached_id]->spot_girth();
+        if (g > 0.0)
+          L.girth = g * 1.1;
       }
     }
     for (int &ign : L.ignore_ids)

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -5,10 +5,11 @@ namespace rt
 {
 PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
                        std::vector<int> ignore_ids, int attached_id,
-                       const Vec3 &dir, double cutoff)
+                       const Vec3 &dir, double cutoff, double range,
+                       double girth)
     : position(p), color(c), intensity(i),
       ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
-      direction(dir), cutoff_cos(cutoff)
+      direction(dir), cutoff_cos(cutoff), range(range), girth(girth)
 {}
 
 Ambient::Ambient(const Vec3 &c, double i) : color(c), intensity(i) {}

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -24,10 +24,23 @@ Vec3 phong(const Material &m, const Ambient &ambient,
            col.z * ambient.color.z * ambient.intensity);
   for (const auto &L : lights)
   {
-    Vec3 ldir = (L.position - p).normalized();
-    if (L.cutoff_cos > -1.0)
+    Vec3 from_light = p - L.position;
+    double dist_to_light = from_light.length();
+    if (L.range > 0.0 && dist_to_light > L.range)
+      continue;
+    Vec3 ldir = (from_light * -1.0).normalized();
+    if (L.girth > 0.0 && L.direction.length_squared() > 0.0)
     {
-      Vec3 spot_dir = (p - L.position).normalized();
+      double along = Vec3::dot(from_light, L.direction);
+      if (along < 0.0 || (L.range > 0.0 && along > L.range))
+        continue;
+      Vec3 radial = from_light - L.direction * along;
+      if (radial.length_squared() > L.girth * L.girth)
+        continue;
+    }
+    else if (L.cutoff_cos > -1.0)
+    {
+      Vec3 spot_dir = from_light.normalized();
       if (Vec3::dot(L.direction, spot_dir) < L.cutoff_cos)
         continue;
     }
@@ -35,9 +48,12 @@ Vec3 phong(const Material &m, const Ambient &ambient,
     Vec3 h = (ldir + eye).normalized();
     double spec =
         std::pow(std::max(0.0, Vec3::dot(n, h)), m.specular_exp) * m.specular_k;
-    c += Vec3(col.x * L.color.x * L.intensity * diff + L.color.x * spec,
-              col.y * L.color.y * L.intensity * diff + L.color.y * spec,
-              col.z * L.color.z * L.intensity * diff + L.color.z * spec);
+    double intensity = L.intensity;
+    if (L.range > 0.0)
+      intensity *= std::max(0.0, 1.0 - dist_to_light / L.range);
+    c += Vec3(col.x * L.color.x * intensity * diff + L.color.x * spec,
+              col.y * L.color.y * intensity * diff + L.color.y * spec,
+              col.z * L.color.z * intensity * diff + L.color.z * spec);
   }
   return c;
 }


### PR DESCRIPTION
## Summary
- extend PointLight with range and girth parameters for beam-style spotlights
- expose range and girth from BeamSource and propagate to lights
- apply range falloff and girth checks during shading

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `./build/minirt scenes/test.rt 10 10 L` *(fails: XDG_RUNTIME_DIR is invalid)*


------
https://chatgpt.com/codex/tasks/task_e_68b6ef602810832fbc2c9498da0576e6