### PR TITLE
Refine beam light into spotlight with girth and range falloff

### DIFF
--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -14,10 +14,13 @@ struct PointLight
   int attached_id;
   Vec3 direction;
   double cutoff_cos;
+  double range;
+  double girth;
 
   PointLight(const Vec3 &p, const Vec3 &c, double i,
              std::vector<int> ignore_ids = {}, int attached_id = -1,
-             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
+             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0,
+             double range = -1.0, double girth = -1.0);
 };
 
 struct Ambient

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -326,11 +326,10 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
         outScene.lights.emplace_back(
             o, unit, 0.75,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
-            src->object_id, dir_norm, cone_cos);
+            src->object_id, dir_norm, -1.0, L, g * 1.1);
       }
     }
     else if (id == "co")

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -111,6 +111,22 @@ void Scene::update_beams(const std::vector<Material> &mats)
         Vec3 dir = objects[L.attached_id]->spot_direction();
         if (dir.length_squared() > 0)
           L.direction = dir.normalized();
+        for (const auto &obj : objects)
+        {
+          if (!obj->is_beam())
+            continue;
+          auto bm = std::static_pointer_cast<Beam>(obj);
+          if (auto src = bm->source.lock())
+          {
+            if (src->object_id == L.attached_id && bm->start <= 0.0)
+            {
+              L.range = bm->length;
+              L.girth = bm->radius * 1.1;
+              L.direction = bm->path.dir.normalized();
+              break;
+            }
+          }
+        }
       }
     }
     for (int &ign : L.ignore_ids)

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -5,10 +5,11 @@ namespace rt
 {
 PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
                        std::vector<int> ignore_ids, int attached_id,
-                       const Vec3 &dir, double cutoff)
+                       const Vec3 &dir, double cutoff,
+                       double r, double g)
     : position(p), color(c), intensity(i),
       ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
-      direction(dir), cutoff_cos(cutoff)
+      direction(dir), cutoff_cos(cutoff), range(r), girth(g)
 {}
 
 Ambient::Ambient(const Vec3 &c, double i) : color(c), intensity(i) {}

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -24,20 +24,30 @@ Vec3 phong(const Material &m, const Ambient &ambient,
            col.z * ambient.color.z * ambient.intensity);
   for (const auto &L : lights)
   {
-    Vec3 ldir = (L.position - p).normalized();
-    if (L.cutoff_cos > -1.0)
+    Vec3 to_pt = p - L.position;
+    double falloff = 1.0;
+    if (L.girth > 0 || L.range > 0 || L.direction.length_squared() > 0.0)
     {
-      Vec3 spot_dir = (p - L.position).normalized();
-      if (Vec3::dot(L.direction, spot_dir) < L.cutoff_cos)
+      double t = Vec3::dot(to_pt, L.direction);
+      if (t < 0.0)
         continue;
+      if (L.range > 0.0 && t > L.range)
+        continue;
+      Vec3 radial = to_pt - L.direction * t;
+      if (L.girth > 0.0 && radial.length_squared() > L.girth * L.girth)
+        continue;
+      if (L.range > 0.0)
+        falloff = std::max(0.0, 1.0 - t / L.range);
     }
+    Vec3 ldir = (L.position - p).normalized();
     double diff = std::max(0.0, Vec3::dot(n, ldir));
     Vec3 h = (ldir + eye).normalized();
     double spec =
         std::pow(std::max(0.0, Vec3::dot(n, h)), m.specular_exp) * m.specular_k;
-    c += Vec3(col.x * L.color.x * L.intensity * diff + L.color.x * spec,
-              col.y * L.color.y * L.intensity * diff + L.color.y * spec,
-              col.z * L.color.z * L.intensity * diff + L.color.z * spec);
+    Vec3 contrib(col.x * L.color.x * L.intensity * diff + L.color.x * spec,
+                 col.y * L.color.y * L.intensity * diff + L.color.y * spec,
+                 col.z * L.color.z * L.intensity * diff + L.color.z * spec);
+    c += contrib * falloff;
   }
   return c;
 }


### PR DESCRIPTION
## Summary
- Add range and girth controls to `PointLight` to model spotlight-like beams
- Constrain light contribution within beam cylinder and apply linear falloff
- Keep light range/girth synced to underlying beam geometry

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b6ef602810832fbc2c9498da0576e6