### PR TITLE
Add spotlight range and falloff for beam lights

### DIFF
--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -10,12 +10,13 @@ struct PointLight
   Vec3 position;
   Vec3 color;
   double intensity;
+  double range;
   std::vector<int> ignore_ids;
   int attached_id;
   Vec3 direction;
   double cutoff_cos;
 
-  PointLight(const Vec3 &p, const Vec3 &c, double i,
+  PointLight(const Vec3 &p, const Vec3 &c, double i, double range = -1.0,
              std::vector<int> ignore_ids = {}, int attached_id = -1,
              const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
 };

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -326,9 +326,13 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+        double light_range = L;
+        double light_girth = g * 1.1;
+        double cone_cos = light_range /
+                          std::sqrt(light_range * light_range +
+                                    light_girth * light_girth);
         outScene.lights.emplace_back(
-            o, unit, 0.75,
+            o, unit, 0.75, light_range,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
             src->object_id, dir_norm, cone_cos);
       }

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -3,10 +3,10 @@
 
 namespace rt
 {
-PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
+PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i, double r,
                        std::vector<int> ignore_ids, int attached_id,
                        const Vec3 &dir, double cutoff)
-    : position(p), color(c), intensity(i),
+    : position(p), color(c), intensity(i), range(r),
       ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
       direction(dir), cutoff_cos(cutoff)
 {}

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -24,20 +24,30 @@ Vec3 phong(const Material &m, const Ambient &ambient,
            col.z * ambient.color.z * ambient.intensity);
   for (const auto &L : lights)
   {
-    Vec3 ldir = (L.position - p).normalized();
+    Vec3 to_light = L.position - p;
+    double dist = to_light.length();
+    if (L.range > 0.0 && dist > L.range)
+      continue;
+    Vec3 ldir = to_light / dist;
     if (L.cutoff_cos > -1.0)
     {
       Vec3 spot_dir = (p - L.position).normalized();
       if (Vec3::dot(L.direction, spot_dir) < L.cutoff_cos)
         continue;
     }
+    double falloff = 1.0;
+    if (L.range > 0.0)
+      falloff = std::max(0.0, (L.range - dist) / L.range);
     double diff = std::max(0.0, Vec3::dot(n, ldir));
     Vec3 h = (ldir + eye).normalized();
     double spec =
         std::pow(std::max(0.0, Vec3::dot(n, h)), m.specular_exp) * m.specular_k;
-    c += Vec3(col.x * L.color.x * L.intensity * diff + L.color.x * spec,
-              col.y * L.color.y * L.intensity * diff + L.color.y * spec,
-              col.z * L.color.z * L.intensity * diff + L.color.z * spec);
+    c += Vec3(col.x * L.color.x * L.intensity * diff * falloff +
+                  L.color.x * spec * falloff,
+              col.y * L.color.y * L.intensity * diff * falloff +
+                  L.color.y * spec * falloff,
+              col.z * L.color.z * L.intensity * diff * falloff +
+                  L.color.z * spec * falloff);
   }
   return c;
 }


### PR DESCRIPTION
## Summary
- extend PointLight with range and implement distance-based falloff
- compute beam light cone from beam radius and length
- honor range limits and falloff during lighting and shading calculations

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b6ef602810832fbc2c9498da0576e6