### PR TITLE
Refactor beam into spotlight light

### DIFF
--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -14,10 +14,13 @@ struct PointLight
   int attached_id;
   Vec3 direction;
   double cutoff_cos;
+  double beam_radius;
+  double beam_length;
 
   PointLight(const Vec3 &p, const Vec3 &c, double i,
              std::vector<int> ignore_ids = {}, int attached_id = -1,
-             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
+             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0,
+             double beam_radius = -1.0, double beam_length = -1.0);
 };
 
 struct Ambient

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1,6 +1,4 @@
 #include "rt/Parser.hpp"
-#include "rt/Beam.hpp"
-#include "rt/BeamSource.hpp"
 #include "rt/Cube.hpp"
 #include "rt/Cone.hpp"
 #include "rt/Cylinder.hpp"
@@ -15,7 +13,6 @@
 #include <string_view>
 #include <cstring>
 #include <filesystem>
-#include <unordered_set>
 #include <iomanip>
 
 namespace
@@ -292,45 +289,9 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
           parse_rgba(s_rgb, rgb, a) && to_double(s_g, g) && to_double(s_L, L))
       {
         Vec3 unit = rgb_to_unit(rgb);
-        materials.emplace_back();
-        materials.back().color = unit;
-        materials.back().base_color = unit;
-        materials.back().alpha = alpha_to_unit(a);
-        materials.back().random_alpha = true;
-        int beam_mat = mid++;
-
         Vec3 dir_norm = dir.normalized();
-        auto bm = std::make_shared<Beam>(o, dir_norm, g, L, oid++, beam_mat);
-
-        materials.emplace_back();
-        materials.back().color = Vec3(1.0, 1.0, 1.0);
-        materials.back().base_color = materials.back().color;
-        materials.back().alpha = 0.25;
-        int big_mat = mid++;
-
-        materials.emplace_back();
-        materials.back().color = (Vec3(1.0, 1.0, 1.0) + unit) * 0.5;
-        materials.back().base_color = materials.back().color;
-        materials.back().alpha = 0.5;
-        int mid_mat = mid++;
-
-        materials.emplace_back();
-        materials.back().color = unit;
-        materials.back().base_color = unit;
-        materials.back().alpha = 1.0;
-        int small_mat = mid++;
-
-        auto src = std::make_shared<BeamSource>(o, dir_norm, bm, oid++,
-                                                big_mat, mid_mat, small_mat);
-        src->movable = (s_move == "M");
-        bm->source = src;
-        outScene.objects.push_back(bm);
-        outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
-        outScene.lights.emplace_back(
-            o, unit, 0.75,
-            std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
-            src->object_id, dir_norm, cone_cos);
+        outScene.lights.emplace_back(o, unit, 0.75, std::vector<int>{}, -1,
+                                     dir_norm, -1.0, g, L);
       }
     }
     else if (id == "co")
@@ -407,33 +368,8 @@ bool Parser::save_rt_file(const std::string &path, const Scene &scene,
         << rgba_to_str(L.color, 1.0) << '\n';
   }
 
-  std::unordered_set<int> beam_sources;
   for (const auto &obj : scene.objects)
   {
-    if (obj->is_beam())
-    {
-      auto bm = std::static_pointer_cast<Beam>(obj);
-      if (bm->start > 0.0)
-        continue;
-      if (auto src = bm->source.lock())
-        beam_sources.insert(src->object_id);
-      const Material &m = mats[bm->material_id];
-      out << "bm " << vec_to_str(bm->path.orig) << ' '
-          << vec_to_str(bm->path.dir) << ' '
-          << rgba_to_str(m.base_color, m.alpha) << ' '
-          << bm->radius << ' ' << bm->total_length;
-      if (auto src = bm->source.lock(); src && src->movable)
-        out << " M";
-      out << '\n';
-    }
-  }
-
-  for (const auto &obj : scene.objects)
-  {
-    if (obj->is_beam())
-      continue;
-    if (beam_sources.count(obj->object_id))
-      continue;
     const Material &m = mats[obj->material_id];
     std::string mirror = m.mirror ? "R" : "NR";
     std::string move = obj->movable ? "M" : "IM";

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -71,13 +71,35 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
     if (std::find(L.ignore_ids.begin(), L.ignore_ids.end(), rec.object_id) !=
         L.ignore_ids.end())
       continue;
-    Vec3 to_light = L.position - rec.p;
-    Vec3 ldir = to_light.normalized();
+    Vec3 from_light = rec.p - L.position;
+    Vec3 ldir = (from_light * -1.0).normalized();
     if (L.cutoff_cos > -1.0)
     {
       Vec3 spot_dir = (rec.p - L.position).normalized();
       if (Vec3::dot(L.direction, spot_dir) < L.cutoff_cos)
         continue;
+    }
+    if (L.beam_length > 0.0)
+    {
+      double proj = Vec3::dot(L.direction, from_light);
+      if (proj < 0.0 || proj > L.beam_length)
+        continue;
+      Vec3 radial = from_light - L.direction * proj;
+      if (radial.length_squared() > L.beam_radius * L.beam_radius)
+        continue;
+      double falloff = 1.0 - proj / L.beam_length;
+      if (in_shadow(scene, rec.p, L))
+        continue;
+      double diff =
+          std::max(0.0, Vec3::dot(rec.normal, ldir)) * falloff;
+      Vec3 h = (ldir + eye).normalized();
+      double spec =
+          std::pow(std::max(0.0, Vec3::dot(rec.normal, h)), m.specular_exp) *
+          m.specular_k * falloff;
+      sum += Vec3(col.x * L.color.x * L.intensity * diff + L.color.x * spec,
+                  col.y * L.color.y * L.intensity * diff + L.color.y * spec,
+                  col.z * L.color.z * L.intensity * diff + L.color.z * spec);
+      continue;
     }
     if (in_shadow(scene, rec.p, L))
       continue;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,125 +1,15 @@
 #include "rt/Scene.hpp"
-#include "rt/Beam.hpp"
 #include "rt/Plane.hpp"
 #include "rt/Collision.hpp"
 #include "rt/Camera.hpp"
 #include <algorithm>
 #include <limits>
-#include <unordered_map>
-
-namespace
-{
-inline rt::Vec3 reflect(const rt::Vec3 &v, const rt::Vec3 &n)
-{
-  return v - n * (2.0 * rt::Vec3::dot(v, n));
-}
-
-} // namespace
 
 namespace rt
 {
-void Scene::update_beams(const std::vector<Material> &mats)
+void Scene::update_beams(const std::vector<Material> &)
 {
-  std::vector<std::shared_ptr<Beam>> roots;
-  std::vector<HittablePtr> non_beams;
-  non_beams.reserve(objects.size());
-  std::unordered_map<int, int> id_map;
-
-  for (auto &obj : objects)
-  {
-    if (obj->is_beam())
-    {
-      auto bm = std::static_pointer_cast<Beam>(obj);
-      if (bm->start <= 0.0)
-      {
-        bm->start = 0.0;
-        bm->length = bm->total_length;
-        roots.push_back(bm);
-      }
-      continue;
-    }
-    non_beams.push_back(obj);
-  }
-
-  for (size_t i = 0; i < non_beams.size(); ++i)
-  {
-    id_map[non_beams[i]->object_id] = static_cast<int>(i);
-    non_beams[i]->object_id = static_cast<int>(i);
-  }
-
-  objects = std::move(non_beams);
-  int next_oid = static_cast<int>(objects.size());
-
-  std::vector<std::shared_ptr<Beam>> to_process = roots;
-  for (size_t i = 0; i < to_process.size(); ++i)
-  {
-    auto bm = to_process[i];
-    if (i < roots.size())
-      id_map[bm->object_id] = next_oid;
-    bm->object_id = next_oid;
-    objects.push_back(bm);
-    ++next_oid;
-
-    Ray forward(bm->path.orig, bm->path.dir);
-    HitRecord tmp, hit_rec;
-    bool hit_any = false;
-    double closest = bm->length;
-    for (auto &other : objects)
-    {
-      if (other.get() == bm.get())
-        continue;
-      if (auto src = bm->source.lock())
-        if (other.get() == src.get())
-          continue;
-      if (other->hit(forward, 1e-4, closest, tmp))
-      {
-        closest = tmp.t;
-        hit_rec = tmp;
-        hit_any = true;
-      }
-    }
-    if (hit_any)
-    {
-      bm->length = closest;
-      if (mats[hit_rec.material_id].mirror)
-      {
-        double new_start = bm->start + closest;
-        double new_len = bm->total_length - new_start;
-        if (new_len > 1e-4)
-        {
-          Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
-          Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
-          auto new_bm = std::make_shared<Beam>(refl_orig, refl_dir, bm->radius,
-                                               new_len, 0, bm->material_id,
-                                               new_start, bm->total_length);
-          new_bm->source = bm->source;
-          to_process.push_back(new_bm);
-        }
-      }
-    }
-  }
-
-  for (auto &L : lights)
-  {
-    if (L.attached_id >= 0)
-    {
-      auto it = id_map.find(L.attached_id);
-      if (it != id_map.end())
-        L.attached_id = it->second;
-      if (L.attached_id >= 0 && L.attached_id < static_cast<int>(objects.size()))
-      {
-        Vec3 dir = objects[L.attached_id]->spot_direction();
-        if (dir.length_squared() > 0)
-          L.direction = dir.normalized();
-      }
-    }
-    for (int &ign : L.ignore_ids)
-    {
-      auto it = id_map.find(ign);
-      if (it != id_map.end())
-        ign = it->second;
-    }
-  }
+  // Beam objects removed; no processing needed.
 }
 
 void Scene::build_bvh()

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -5,10 +5,10 @@ namespace rt
 {
 PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
                        std::vector<int> ignore_ids, int attached_id,
-                       const Vec3 &dir, double cutoff)
+                       const Vec3 &dir, double cutoff, double br, double bl)
     : position(p), color(c), intensity(i),
       ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
-      direction(dir), cutoff_cos(cutoff)
+      direction(dir), cutoff_cos(cutoff), beam_radius(br), beam_length(bl)
 {}
 
 Ambient::Ambient(const Vec3 &c, double i) : color(c), intensity(i) {}


### PR DESCRIPTION
## Summary
- Remove geometric beam objects and treat beams as spotlights with girth and length
- Add beam radius and length support to PointLight and renderer
- Simplify scene beam handling

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b83473c548832fa07d729bdef07ebb