### PR TITLE
Scale beam source hole to beam radius

### DIFF
--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -1,5 +1,6 @@
 #include "rt/BeamSource.hpp"
 #include <cmath>
+#include <algorithm>
 
 namespace rt
 {
@@ -33,7 +34,9 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
   {
     Vec3 beam_dir = beam ? beam->path.dir : Vec3(0, 0, 1);
     Vec3 to_hit = (tmp.p - inner.center).normalized();
-    const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    double hole_ratio = beam ? std::clamp(beam->radius / inner.radius, 0.0, 1.0)
+                             : 0.25;
+    const double hole_cos = std::sqrt(1.0 - hole_ratio * hole_ratio);
     if (Vec3::dot(beam_dir, to_hit) < hole_cos)
     {
       hit_any = true;

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -326,7 +326,8 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+        double cone_ratio = std::clamp(g / src->inner.radius, 0.0, 1.0);
+        double cone_cos = std::sqrt(1.0 - cone_ratio * cone_ratio);
         outScene.lights.emplace_back(
             o, unit, 0.75,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},


### PR DESCRIPTION
## Summary
- size beam source aperture based on attached beam radius
- match spotlight cone to beam cylinder width

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b839c68720832f870a112767e8ccfa