### PR TITLE
Add reflective beam lighting with range falloff

### DIFF
--- a/include/rt/Beam.hpp
+++ b/include/rt/Beam.hpp
@@ -13,6 +13,7 @@ struct Beam : public Hittable
   double start;
   double total_length;
   std::weak_ptr<Hittable> source;
+  int ignore_object_id = -1;
   Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
        int oid, int mid, double start = 0.0, double total = -1.0);
 
@@ -20,6 +21,7 @@ struct Beam : public Hittable
   bool bounding_box(AABB &out) const override;
   bool is_beam() const override;
   ShapeType shape_type() const override { return ShapeType::Beam; }
+  Vec3 spot_direction() const override { return path.dir; }
 };
 
 } // namespace rt

--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -14,10 +14,12 @@ struct PointLight
   int attached_id;
   Vec3 direction;
   double cutoff_cos;
+  double range;
 
   PointLight(const Vec3 &p, const Vec3 &c, double i,
              std::vector<int> ignore_ids = {}, int attached_id = -1,
-             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
+             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0,
+             double range = -1.0);
 };
 
 struct Ambient

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -330,7 +330,7 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         outScene.lights.emplace_back(
             o, unit, 0.75,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
-            src->object_id, dir_norm, cone_cos);
+            bm->object_id, dir_norm, cone_cos, L);
       }
     }
     else if (id == "co")

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -5,10 +5,10 @@ namespace rt
 {
 PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
                        std::vector<int> ignore_ids, int attached_id,
-                       const Vec3 &dir, double cutoff)
+                       const Vec3 &dir, double cutoff, double rng)
     : position(p), color(c), intensity(i),
       ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
-      direction(dir), cutoff_cos(cutoff)
+      direction(dir), cutoff_cos(cutoff), range(rng)
 {}
 
 Ambient::Ambient(const Vec3 &c, double i) : color(c), intensity(i) {}

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -24,17 +24,22 @@ Vec3 phong(const Material &m, const Ambient &ambient,
            col.z * ambient.color.z * ambient.intensity);
   for (const auto &L : lights)
   {
-    Vec3 ldir = (L.position - p).normalized();
+    Vec3 to_light = L.position - p;
+    double dist = to_light.length();
+    if (L.range > 0.0 && dist > L.range)
+      continue;
+    Vec3 ldir = to_light.normalized();
     if (L.cutoff_cos > -1.0)
     {
       Vec3 spot_dir = (p - L.position).normalized();
       if (Vec3::dot(L.direction, spot_dir) < L.cutoff_cos)
         continue;
     }
-    double diff = std::max(0.0, Vec3::dot(n, ldir));
+    double falloff = (L.range > 0.0) ? std::max(0.0, 1.0 - dist / L.range) : 1.0;
+    double diff = std::max(0.0, Vec3::dot(n, ldir)) * falloff;
     Vec3 h = (ldir + eye).normalized();
     double spec =
-        std::pow(std::max(0.0, Vec3::dot(n, h)), m.specular_exp) * m.specular_k;
+        std::pow(std::max(0.0, Vec3::dot(n, h)), m.specular_exp) * m.specular_k * falloff;
     c += Vec3(col.x * L.color.x * L.intensity * diff + L.color.x * spec,
               col.y * L.color.y * L.intensity * diff + L.color.y * spec,
               col.z * L.color.z * L.intensity * diff + L.color.z * spec);


### PR DESCRIPTION
## Summary
- add distance-based range support to point lights
- generate reflected beam lights with the same range and direction as the beam
- apply linear falloff when shading surfaces using beam lights

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b840f73a1c832fa468a194e5a54dcc