### PR TITLE
Fix beam reflection light propagation

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -126,18 +126,6 @@ void Scene::update_beams(const std::vector<Material> &mats)
     }
   }
 
-  for (const auto &pl : pending_lights)
-  {
-    auto bm = pl.beam;
-    Vec3 light_col = mats[bm->material_id].base_color;
-    const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
-    double remain = bm->total_length - bm->start;
-    double ratio = (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
-    lights.emplace_back(bm->path.orig, light_col, bm->light_intensity * ratio,
-                        std::vector<int>{bm->object_id, pl.hit_id}, bm->object_id,
-                        bm->path.dir, cone_cos, bm->length);
-  }
-
   for (auto &L : lights)
   {
     if (L.attached_id >= 0)
@@ -158,6 +146,18 @@ void Scene::update_beams(const std::vector<Material> &mats)
       if (it != id_map.end())
         ign = it->second;
     }
+  }
+
+  for (const auto &pl : pending_lights)
+  {
+    auto bm = pl.beam;
+    Vec3 light_col = mats[bm->material_id].base_color;
+    const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    double remain = bm->total_length - bm->start;
+    double ratio = (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
+    lights.emplace_back(bm->path.orig, light_col, bm->light_intensity * ratio,
+                        std::vector<int>{bm->object_id, pl.hit_id}, bm->object_id,
+                        bm->path.dir, cone_cos, bm->length);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure dynamic lights for reflected beams aren't remapped incorrectly by reordering light updates

## Testing
- `cmake ..`
- `cmake --build .`
- `./minirt ../scenes/box.rt 100 100 L` *(fails: XDG_RUNTIME_DIR is invalid or not set in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b85b211fc8832f8196b621ef124b2e