### PR TITLE
Fix beam reflection lighting

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -97,6 +97,8 @@ void Scene::update_beams(const std::vector<Material> &mats)
       if (auto src = bm->source.lock())
         if (other.get() == src.get())
           continue;
+      if (other->is_beam())
+        continue;
       if (other->hit(forward, 1e-4, closest, tmp))
       {
         closest = tmp.t;


### PR DESCRIPTION
## Summary
- ignore beam objects when tracing beam reflections so reflected beams generate lights

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68b85b211fc8832f8196b621ef124b2e