### PR TITLE
Generate consistent beam lights at reflection points

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -130,10 +130,14 @@ void Scene::update_beams(const std::vector<Material> &mats)
   {
     auto bm = pl.beam;
     Vec3 light_col = mats[bm->material_id].base_color;
-    const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
-    double remain = bm->total_length - bm->start;
-    double ratio = (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
-    lights.emplace_back(bm->path.orig, light_col, bm->light_intensity * ratio,
+    double cone_cos = 1.0;
+    if (bm->length > 0.0)
+    {
+      double r = bm->radius;
+      double len = bm->length;
+      cone_cos = len / std::sqrt(len * len + r * r);
+    }
+    lights.emplace_back(bm->path.orig, light_col, bm->light_intensity,
                         std::vector<int>{bm->object_id, pl.hit_id}, bm->object_id,
                         bm->path.dir, cone_cos, bm->length);
   }


### PR DESCRIPTION
## Summary
- Create light sources at reflection points without reducing intensity
- Shape reflected lights based on beam radius and length for consistent beam girth

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68b86e225fa8832f8d95541c01afe670