### PR TITLE
Create light sources on beam reflections with preserved intensity

### DIFF
--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -331,13 +331,18 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+        double cone_cos = 1.0;
+        if (L > 0.0)
+        {
+          double denom = std::sqrt(L * L + g * g);
+          cone_cos = L / denom;
+        }
         outScene.lights.emplace_back(
             o, unit, intensity,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
             src->object_id, dir_norm, cone_cos, L);
+        }
       }
-    }
     else if (id == "co")
     {
       std::string s_pos, s_dir, s_d, s_h, s_rgb;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -130,10 +130,14 @@ void Scene::update_beams(const std::vector<Material> &mats)
   {
     auto bm = pl.beam;
     Vec3 light_col = mats[bm->material_id].base_color;
-    const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
-    double remain = bm->total_length - bm->start;
-    double ratio = (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
-    lights.emplace_back(bm->path.orig, light_col, bm->light_intensity * ratio,
+    double cone_cos = 1.0;
+    if (bm->length > 0.0)
+    {
+      double denom = std::sqrt(bm->length * bm->length +
+                                bm->radius * bm->radius);
+      cone_cos = bm->length / denom;
+    }
+    lights.emplace_back(bm->path.orig, light_col, bm->light_intensity,
                         std::vector<int>{bm->object_id, pl.hit_id}, bm->object_id,
                         bm->path.dir, cone_cos, bm->length);
   }


### PR DESCRIPTION
## Summary
- spawn new point lights at beam reflections using beam's original intensity
- calculate spotlight cone from beam radius and remaining length for accurate shape
- apply same cone calculation when parsing initial beams

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b86e225fa8832f8d95541c01afe670