### PR TITLE
Remove spotlight cone from reflected beams

### DIFF
--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -331,11 +331,10 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
         outScene.lights.emplace_back(
             o, unit, intensity,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
-            src->object_id, dir_norm, cone_cos, L);
+            src->object_id, dir_norm, -1.0, L);
       }
     }
     else if (id == "co")

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -130,12 +130,11 @@ void Scene::update_beams(const std::vector<Material> &mats)
   {
     auto bm = pl.beam;
     Vec3 light_col = mats[bm->material_id].base_color;
-    const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
     double remain = bm->total_length - bm->start;
     double ratio = (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
     lights.emplace_back(bm->path.orig, light_col, bm->light_intensity * ratio,
                         std::vector<int>{bm->object_id, pl.hit_id}, bm->object_id,
-                        bm->path.dir, cone_cos, bm->length);
+                        bm->path.dir, -1.0, bm->length);
   }
 
   for (auto &L : lights)


### PR DESCRIPTION
## Summary
- Remove directional cutoff from beam lights so reflections illuminate all objects within range
- Use isotropic point lights for beams in parser and beam updates

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b878501930832fb573e1290ac74802