### PR TITLE
Remove cylindrical beam representation

### DIFF
--- a/include/rt/Beam.hpp
+++ b/include/rt/Beam.hpp
@@ -8,15 +8,13 @@ namespace rt
 struct Beam : public Hittable
 {
   Ray path;
-  double radius;
   double length;
   double start;
   double total_length;
   double light_intensity;
   std::weak_ptr<Hittable> source;
-  Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
-       double intensity, int oid, int mid, double start = 0.0,
-       double total = -1.0);
+  Beam(const Vec3 &origin, const Vec3 &dir, double length, double intensity,
+       int oid, int mid, double start = 0.0, double total = -1.0);
 
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override;

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -4,9 +4,9 @@
 
 namespace rt
 {
-Beam::Beam(const Vec3 &origin, const Vec3 &dir, double r, double len,
-           double intensity, int oid, int mid, double s, double total)
-    : path(origin, dir.normalized()), radius(r), length(len), start(s),
+Beam::Beam(const Vec3 &origin, const Vec3 &dir, double len, double intensity,
+           int oid, int mid, double s, double total)
+    : path(origin, dir.normalized()), length(len), start(s),
       total_length(total < 0 ? len : total), light_intensity(intensity)
 {
   object_id = oid;
@@ -15,60 +15,11 @@ Beam::Beam(const Vec3 &origin, const Vec3 &dir, double r, double len,
 
 bool Beam::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
-  Vec3 u = r.dir;
-  Vec3 v = path.dir;
-  Vec3 w0 = r.orig - path.orig;
-  double a = Vec3::dot(u, u);
-  double b = Vec3::dot(u, v);
-  double c = Vec3::dot(v, v);
-  double d = Vec3::dot(u, w0);
-  double e = Vec3::dot(v, w0);
-  double denom = a * c - b * b;
-
-  double sc, tc;
-  if (std::fabs(denom) < 1e-9)
-  {
-    sc = -d / a;
-    tc = (a * e - b * d) / (a * c);
-  }
-  else
-  {
-    sc = (b * e - c * d) / denom;
-    tc = (a * e - b * d) / denom;
-  }
-
-  if (sc < tmin || sc > tmax)
-    return false;
-  if (tc < 0.0 || tc > length)
-    return false;
-
-  Vec3 pr = r.at(sc);
-  Vec3 pb = path.at(tc);
-  Vec3 diff = pr - pb;
-  double dist2 = diff.length_squared();
-  if (dist2 > radius * radius)
-    return false;
-
-  Vec3 outward;
-  if (dist2 > 1e-12)
-  {
-    outward = diff.normalized();
-  }
-  else
-  {
-    outward = Vec3::cross(path.dir, Vec3(1, 0, 0));
-    if (outward.length_squared() < 1e-12)
-      outward = Vec3::cross(path.dir, Vec3(0, 1, 0));
-    outward = outward.normalized();
-  }
-
-  rec.t = sc;
-  rec.p = pr;
-  rec.object_id = object_id;
-  rec.material_id = material_id;
-  rec.beam_ratio = (start + tc) / total_length;
-  rec.set_face_normal(r, outward);
-  return true;
+  (void)r;
+  (void)tmin;
+  (void)tmax;
+  (void)rec;
+  return false;
 }
 
 bool Beam::bounding_box(AABB &out) const
@@ -79,8 +30,7 @@ bool Beam::bounding_box(AABB &out) const
            std::min(start.z, end.z));
   Vec3 max(std::max(start.x, end.x), std::max(start.y, end.y),
            std::max(start.z, end.z));
-  Vec3 ex(radius, radius, radius);
-  out = AABB(min - ex, max + ex);
+  out = AABB(min, max);
   return true;
 }
 

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -282,6 +282,7 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
     {
       std::string s_pos, s_dir, s_rgb, s_g, s_L;
       iss >> s_pos >> s_dir >> s_rgb >> s_g >> s_L;
+      (void)s_g;
       std::string s_move;
       if (!(iss >> s_move))
         s_move = "IM";
@@ -289,10 +290,10 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
       if (!(iss >> s_intens))
         s_intens = "0.75";
       Vec3 o, dir, rgb;
-      double g = 0.1, L = 1.0, intensity = 0.75;
+      double L = 1.0, intensity = 0.75;
       double a = 255;
       if (parse_triple(s_pos, o) && parse_triple(s_dir, dir) &&
-          parse_rgba(s_rgb, rgb, a) && to_double(s_g, g) && to_double(s_L, L) &&
+          parse_rgba(s_rgb, rgb, a) && to_double(s_L, L) &&
           to_double(s_intens, intensity))
       {
         Vec3 unit = rgb_to_unit(rgb);
@@ -304,7 +305,7 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         int beam_mat = mid++;
 
         Vec3 dir_norm = dir.normalized();
-        auto bm = std::make_shared<Beam>(o, dir_norm, g, L, intensity,
+        auto bm = std::make_shared<Beam>(o, dir_norm, L, intensity,
                                          oid++, beam_mat);
 
         materials.emplace_back();
@@ -429,7 +430,7 @@ bool Parser::save_rt_file(const std::string &path, const Scene &scene,
       out << "bm " << vec_to_str(bm->path.orig) << ' '
           << vec_to_str(bm->path.dir) << ' '
           << rgba_to_str(m.base_color, m.alpha) << ' '
-          << bm->radius << ' ' << bm->total_length << ' ' << move << ' '
+          << 0.0 << ' ' << bm->total_length << ' ' << move << ' '
           << bm->light_intensity << '\n';
     }
   }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -116,7 +116,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
           Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
           Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
           auto new_bm = std::make_shared<Beam>(
-              refl_orig, refl_dir, bm->radius, new_len, bm->light_intensity, 0,
+              refl_orig, refl_dir, new_len, bm->light_intensity, 0,
               bm->material_id, new_start, bm->total_length);
           new_bm->source = bm->source;
           to_process.push_back(new_bm);
@@ -166,7 +166,7 @@ void Scene::build_bvh()
   std::vector<HittablePtr> objs;
   objs.reserve(objects.size());
   for (auto &o : objects)
-    if (!o->is_plane())
+    if (!o->is_plane() && !o->is_beam())
       objs.push_back(o);
   if (objs.empty())
   {


### PR DESCRIPTION
## Summary
- Drop radius from Beam to model it as a ray-based light source
- Update beam parsing and serialization to ignore radius
- Exclude beams from BVH acceleration structure and spawn reflections without radius

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68b94e96fdb0832f8d35ffd106f832e2