### PR TITLE
Handle reflected beam lights

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -130,10 +130,21 @@ void Scene::update_beams(const std::vector<Material> &mats)
   {
     auto bm = pl.beam;
     Vec3 light_col = mats[bm->material_id].base_color;
-    const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+
     double remain = bm->total_length - bm->start;
     double ratio = (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
-    lights.emplace_back(bm->path.orig, light_col, bm->light_intensity * ratio,
+
+    Vec3 light_pos = bm->path.orig + bm->path.dir * 1e-4;
+
+    double cone_cos = -1.0;
+    if (bm->length > 0.0)
+    {
+      double ang_sin = bm->radius / bm->length;
+      if (ang_sin < 1.0)
+        cone_cos = std::sqrt(1.0 - ang_sin * ang_sin);
+    }
+
+    lights.emplace_back(light_pos, light_col, bm->light_intensity * ratio,
                         std::vector<int>{bm->object_id, pl.hit_id}, bm->object_id,
                         bm->path.dir, cone_cos, bm->length);
   }


### PR DESCRIPTION
## Summary
- offset reflected beam light slightly away from surface
- derive spotlight cone from beam radius and preserve remaining intensity

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b954be86fc832f94cf0de319932adf