### PR TITLE
Ignore beams during reflection tracing

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -97,6 +97,8 @@ void Scene::update_beams(const std::vector<Material> &mats)
       if (auto src = bm->source.lock())
         if (other.get() == src.get())
           continue;
+      if (other->is_beam())
+        continue;
       if (other->hit(forward, 1e-4, closest, tmp))
       {
         closest = tmp.t;


### PR DESCRIPTION
## Summary
- Prevent beams from blocking reflected rays by skipping other beams during hit tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`


------
https://chatgpt.com/codex/tasks/task_e_68b954be86fc832f94cf0de319932adf