### PR TITLE
Rework beam structure and parsing

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -10,8 +10,9 @@ struct BeamSource : public Sphere
   Sphere mid;
   Sphere inner;
   std::shared_ptr<Beam> beam;
-  BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Beam> &bm,
-             int oid, int mat_big, int mat_mid, int mat_small);
+  BeamSource(const Vec3 &c, const Vec3 &dir, double radius,
+             const std::shared_ptr<Beam> &bm, int oid, int mat_big,
+             int mat_mid, int mat_small);
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }
   void translate(const Vec3 &delta) override;

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -1,15 +1,17 @@
 #include "rt/BeamSource.hpp"
+#include <algorithm>
 #include <cmath>
 
 namespace rt
 {
-BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
-                       const std::shared_ptr<Beam> &bm, int oid,
-                       int mat_big, int mat_mid, int mat_small)
-    : Sphere(c, 0.6, oid, mat_big),
-      mid(c, 0.6 * 0.67, -oid - 1, mat_mid),
-      inner(c, 0.6 * 0.33, -oid - 2, mat_small), beam(bm)
+BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir, double radius,
+                       const std::shared_ptr<Beam> &bm, int oid, int mat_big,
+                       int mat_mid, int mat_small)
+    : Sphere(c, radius * 1.33 * 1.33, oid, mat_big),
+      mid(c, radius * 1.33, -oid - 1, mat_mid),
+      inner(c, radius, -oid - 2, mat_small), beam(bm)
 {
+  (void)dir;
 }
 
 bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
@@ -33,7 +35,9 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
   {
     Vec3 beam_dir = beam ? beam->path.dir : Vec3(0, 0, 1);
     Vec3 to_hit = (tmp.p - inner.center).normalized();
-    const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    double ratio = beam ? beam->radius / inner.radius : 0.25;
+    ratio = std::clamp(ratio, 0.0, 1.0);
+    const double hole_cos = std::sqrt(1.0 - ratio * ratio);
     if (Vec3::dot(beam_dir, to_hit) < hole_cos)
     {
       hit_any = true;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -111,7 +111,13 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
     sum = sum * (1.0 - refl_ratio) + refl_col * refl_ratio;
   }
   double alpha = m.alpha;
-  if (m.random_alpha)
+  if (rec.object_id >= 0 && rec.object_id < static_cast<int>(scene.objects.size()) &&
+      scene.objects[rec.object_id]->is_beam())
+  {
+    double tpos = std::clamp(rec.beam_ratio, 0.0, 1.0);
+    alpha *= (1.0 - tpos);
+  }
+  else if (m.random_alpha)
   {
     double tpos = std::clamp(rec.beam_ratio, 0.0, 1.0);
     double rand = (1.0 - tpos) * std::pow(dist(rng), tpos);


### PR DESCRIPTION
## Summary
- Parse beams from new format with intensity, radius and length; create source spheres with updated colors and transparency
- Tie beam transparency to distance along beam for smooth laser falloff
- Build beam source from three concentric spheres sized from beam radius

## Testing
- ❌ `cmake ..` *(missing SDL2 dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b9685ed800832fbd4bda078527836e