### PR TITLE
Refactor beam system with source spheres and light falloff

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -11,7 +11,7 @@ struct BeamSource : public Sphere
   Sphere inner;
   std::shared_ptr<Beam> beam;
   BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Beam> &bm,
-             int oid, int mat_big, int mat_mid, int mat_small);
+             double radius, int oid, int mat_big, int mat_mid, int mat_small);
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }
   void translate(const Vec3 &delta) override;

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -39,6 +39,7 @@ struct Hittable
   bool movable = false;
   int object_id = 0;
   int material_id = 0;
+  bool casts_shadow = true;
   virtual ~Hittable() = default;
   virtual bool hit(const Ray &r, double tmin, double tmax,
                    HitRecord &rec) const = 0;

--- a/include/rt/material.hpp
+++ b/include/rt/material.hpp
@@ -16,7 +16,7 @@ struct Material
   double specular_exp = 50.0;
   double specular_k = 0.5;
   bool mirror = false;
-  bool random_alpha = false;
+  bool unlit = false;
   bool checkered = false; // render as checkered pattern when true
 };
 

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -4,12 +4,13 @@
 namespace rt
 {
 BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
-                       const std::shared_ptr<Beam> &bm, int oid,
+                       const std::shared_ptr<Beam> &bm, double radius, int oid,
                        int mat_big, int mat_mid, int mat_small)
-    : Sphere(c, 0.6, oid, mat_big),
-      mid(c, 0.6 * 0.67, -oid - 1, mat_mid),
-      inner(c, 0.6 * 0.33, -oid - 2, mat_small), beam(bm)
+    : Sphere(c, radius * 1.33 * 1.33, oid, mat_big),
+      mid(c, radius * 1.33, -oid - 1, mat_mid),
+      inner(c, radius, -oid - 2, mat_small), beam(bm)
 {
+  casts_shadow = false;
 }
 
 bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
@@ -31,15 +32,9 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
   }
   if (inner.hit(r, tmin, closest, tmp))
   {
-    Vec3 beam_dir = beam ? beam->path.dir : Vec3(0, 0, 1);
-    Vec3 to_hit = (tmp.p - inner.center).normalized();
-    const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
-    if (Vec3::dot(beam_dir, to_hit) < hole_cos)
-    {
-      hit_any = true;
-      closest = tmp.t;
-      rec = tmp;
-    }
+    hit_any = true;
+    closest = tmp.t;
+    rec = tmp;
   }
   return hit_any;
 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -99,6 +99,8 @@ void Scene::update_beams(const std::vector<Material> &mats)
           continue;
       if (other->hit(forward, 1e-4, closest, tmp))
       {
+        if (tmp.object_id < 0)
+          continue;
         closest = tmp.t;
         hit_rec = tmp;
         hit_any = true;
@@ -130,7 +132,12 @@ void Scene::update_beams(const std::vector<Material> &mats)
   {
     auto bm = pl.beam;
     Vec3 light_col = mats[bm->material_id].base_color;
-    const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    double light_radius = bm->radius * 1.33;
+    double cone_cos =
+        (light_radius >= bm->length)
+            ? -1.0
+            : std::sqrt(1.0 - (light_radius / bm->length) *
+                                    (light_radius / bm->length));
     double remain = bm->total_length - bm->start;
     double ratio = (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
     lights.emplace_back(bm->path.orig, light_col, bm->light_intensity * ratio,


### PR DESCRIPTION
## Summary
- overhaul beam parsing to accept intensity-first format and construct three-layer beam sources
- add material/unlit and cast-shadow controls for beam visuals
- implement linear transparency falloff and updated light cone sizing

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68b9685ed800832fbd4bda078527836e