### PR TITLE
Reduce intensity for reflected light sources

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -115,8 +115,9 @@ void Scene::update_beams(const std::vector<Material> &mats)
         {
           Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
           Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
+          double new_intensity = bm->light_intensity * (REFLECTION / 100.0);
           auto new_bm = std::make_shared<Beam>(
-              refl_orig, refl_dir, bm->radius, new_len, bm->light_intensity, 0,
+              refl_orig, refl_dir, bm->radius, new_len, new_intensity, 0,
               bm->material_id, new_start, bm->total_length);
           new_bm->source = bm->source;
           to_process.push_back(new_bm);


### PR DESCRIPTION
## Summary
- Spawn reflected beams with intensity scaled by reflection ratio
- Ensure new light sources from mirrors have weaker output along the reflection direction

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`

------
https://chatgpt.com/codex/tasks/task_e_68b9aba75e24832fad3157f6a8007f72