### PR TITLE
Refactor beam into composite classes

### DIFF
--- a/include/rt/Beam.hpp
+++ b/include/rt/Beam.hpp
@@ -1,28 +1,16 @@
 #pragma once
-#include "Hittable.hpp"
-#include "Ray.hpp"
 #include <memory>
+#include "LightRay.hpp"
+#include "BeamSource.hpp"
+#include "Laser.hpp"
 
-namespace rt
-{
-struct Beam : public Hittable
-{
-  Ray path;
-  double radius;
-  double length;
-  double start;
-  double total_length;
-  double light_intensity;
-  std::weak_ptr<Hittable> source;
+namespace rt {
+struct Beam {
+  std::shared_ptr<BeamSource> source;
+  std::shared_ptr<Laser> laser;
+  std::shared_ptr<LightRay> light;
   Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
-       double intensity, int oid, int mid, double start = 0.0,
-       double total = -1.0);
-
-  bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
-  bool bounding_box(AABB &out) const override;
-  bool is_beam() const override;
-  ShapeType shape_type() const override { return ShapeType::Beam; }
-  Vec3 spot_direction() const override { return path.dir; }
+       double intensity, int &next_oid, int light_mat, int mat_big,
+       int mat_mid, int mat_small);
 };
-
 } // namespace rt

--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "Beam.hpp"
+#include "LightRay.hpp"
 #include "Sphere.hpp"
 #include <memory>
 
@@ -9,8 +9,8 @@ struct BeamSource : public Sphere
 {
   Sphere mid;
   Sphere inner;
-  std::shared_ptr<Beam> beam;
-  BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Beam> &bm,
+  std::shared_ptr<LightRay> beam;
+  BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<LightRay> &bm,
              double radius, int oid, int mat_big, int mat_mid, int mat_small);
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -17,7 +17,7 @@ enum class ShapeType
   Cone,
   Plane,
   BVH,
-  Beam
+  LightRay
 };
 
 struct Material;

--- a/include/rt/Laser.hpp
+++ b/include/rt/Laser.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <memory>
+#include "LightRay.hpp"
+
+namespace rt {
+struct Laser {
+  std::shared_ptr<LightRay> ray;
+  explicit Laser(const std::shared_ptr<LightRay> &r) : ray(r) {}
+};
+} // namespace rt

--- a/include/rt/LightRay.hpp
+++ b/include/rt/LightRay.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "Hittable.hpp"
+#include "Ray.hpp"
+#include <memory>
+
+namespace rt
+{
+struct LightRay : public Hittable
+{
+  Ray path;
+  double radius;
+  double length;
+  double start;
+  double total_length;
+  double light_intensity;
+  std::weak_ptr<Hittable> source;
+  LightRay(const Vec3 &origin, const Vec3 &dir, double radius, double length,
+           double intensity, int oid, int mid, double start = 0.0,
+           double total = -1.0);
+
+  bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
+  bool bounding_box(AABB &out) const override;
+  bool is_beam() const override;
+  ShapeType shape_type() const override { return ShapeType::LightRay; }
+  Vec3 spot_direction() const override { return path.dir; }
+};
+
+} // namespace rt

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -1,89 +1,15 @@
 #include "rt/Beam.hpp"
-#include <algorithm>
-#include <cmath>
 
-namespace rt
+namespace rt {
+Beam::Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
+           double intensity, int &next_oid, int light_mat, int mat_big,
+           int mat_mid, int mat_small)
 {
-Beam::Beam(const Vec3 &origin, const Vec3 &dir, double r, double len,
-           double intensity, int oid, int mid, double s, double total)
-    : path(origin, dir.normalized()), radius(r), length(len), start(s),
-      total_length(total < 0 ? len : total), light_intensity(intensity)
-{
-  object_id = oid;
-  material_id = mid;
+  light = std::make_shared<LightRay>(origin, dir, radius, length, intensity,
+                                     next_oid++, light_mat);
+  source = std::make_shared<BeamSource>(origin, dir, light, radius, next_oid++,
+                                        mat_big, mat_mid, mat_small);
+  light->source = source;
+  laser = std::make_shared<Laser>(light);
 }
-
-bool Beam::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
-{
-  Vec3 u = r.dir;
-  Vec3 v = path.dir;
-  Vec3 w0 = r.orig - path.orig;
-  double a = Vec3::dot(u, u);
-  double b = Vec3::dot(u, v);
-  double c = Vec3::dot(v, v);
-  double d = Vec3::dot(u, w0);
-  double e = Vec3::dot(v, w0);
-  double denom = a * c - b * b;
-
-  double sc, tc;
-  if (std::fabs(denom) < 1e-9)
-  {
-    sc = -d / a;
-    tc = (a * e - b * d) / (a * c);
-  }
-  else
-  {
-    sc = (b * e - c * d) / denom;
-    tc = (a * e - b * d) / denom;
-  }
-
-  if (sc < tmin || sc > tmax)
-    return false;
-  if (tc < 0.0 || tc > length)
-    return false;
-
-  Vec3 pr = r.at(sc);
-  Vec3 pb = path.at(tc);
-  Vec3 diff = pr - pb;
-  double dist2 = diff.length_squared();
-  if (dist2 > radius * radius)
-    return false;
-
-  Vec3 outward;
-  if (dist2 > 1e-12)
-  {
-    outward = diff.normalized();
-  }
-  else
-  {
-    outward = Vec3::cross(path.dir, Vec3(1, 0, 0));
-    if (outward.length_squared() < 1e-12)
-      outward = Vec3::cross(path.dir, Vec3(0, 1, 0));
-    outward = outward.normalized();
-  }
-
-  rec.t = sc;
-  rec.p = pr;
-  rec.object_id = object_id;
-  rec.material_id = material_id;
-  rec.beam_ratio = (start + tc) / total_length;
-  rec.set_face_normal(r, outward);
-  return true;
-}
-
-bool Beam::bounding_box(AABB &out) const
-{
-  Vec3 start = path.orig;
-  Vec3 end = path.at(length);
-  Vec3 min(std::min(start.x, end.x), std::min(start.y, end.y),
-           std::min(start.z, end.z));
-  Vec3 max(std::max(start.x, end.x), std::max(start.y, end.y),
-           std::max(start.z, end.z));
-  Vec3 ex(radius, radius, radius);
-  out = AABB(min - ex, max + ex);
-  return true;
-}
-
-bool Beam::is_beam() const { return true; }
-
 } // namespace rt

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -4,7 +4,7 @@
 namespace rt
 {
 BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
-                       const std::shared_ptr<Beam> &bm, double radius, int oid,
+                       const std::shared_ptr<LightRay> &bm, double radius, int oid,
                        int mat_big, int mat_mid, int mat_small)
     : Sphere(c, radius * (4.0 / 3.0) * (4.0 / 3.0), oid, mat_big),
       mid(c, radius * (4.0 / 3.0), -oid - 1, mat_mid),

--- a/src/LightRay.cpp
+++ b/src/LightRay.cpp
@@ -1,0 +1,89 @@
+#include "rt/LightRay.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace rt
+{
+LightRay::LightRay(const Vec3 &origin, const Vec3 &dir, double r, double len,
+                   double intensity, int oid, int mid, double s, double total)
+    : path(origin, dir.normalized()), radius(r), length(len), start(s),
+      total_length(total < 0 ? len : total), light_intensity(intensity)
+{
+  object_id = oid;
+  material_id = mid;
+}
+
+bool LightRay::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
+{
+  Vec3 u = r.dir;
+  Vec3 v = path.dir;
+  Vec3 w0 = r.orig - path.orig;
+  double a = Vec3::dot(u, u);
+  double b = Vec3::dot(u, v);
+  double c = Vec3::dot(v, v);
+  double d = Vec3::dot(u, w0);
+  double e = Vec3::dot(v, w0);
+  double denom = a * c - b * b;
+
+  double sc, tc;
+  if (std::fabs(denom) < 1e-9)
+  {
+    sc = -d / a;
+    tc = (a * e - b * d) / (a * c);
+  }
+  else
+  {
+    sc = (b * e - c * d) / denom;
+    tc = (a * e - b * d) / denom;
+  }
+
+  if (sc < tmin || sc > tmax)
+    return false;
+  if (tc < 0.0 || tc > length)
+    return false;
+
+  Vec3 pr = r.at(sc);
+  Vec3 pb = path.at(tc);
+  Vec3 diff = pr - pb;
+  double dist2 = diff.length_squared();
+  if (dist2 > radius * radius)
+    return false;
+
+  Vec3 outward;
+  if (dist2 > 1e-12)
+  {
+    outward = diff.normalized();
+  }
+  else
+  {
+    outward = Vec3::cross(path.dir, Vec3(1, 0, 0));
+    if (outward.length_squared() < 1e-12)
+      outward = Vec3::cross(path.dir, Vec3(0, 1, 0));
+    outward = outward.normalized();
+  }
+
+  rec.t = sc;
+  rec.p = pr;
+  rec.object_id = object_id;
+  rec.material_id = material_id;
+  rec.beam_ratio = (start + tc) / total_length;
+  rec.set_face_normal(r, outward);
+  return true;
+}
+
+bool LightRay::bounding_box(AABB &out) const
+{
+  Vec3 start = path.orig;
+  Vec3 end = path.at(length);
+  Vec3 min(std::min(start.x, end.x), std::min(start.y, end.y),
+           std::min(start.z, end.z));
+  Vec3 max(std::max(start.x, end.x), std::max(start.y, end.y),
+           std::max(start.z, end.z));
+  Vec3 ex(radius, radius, radius);
+  out = AABB(min - ex, max + ex);
+  return true;
+}
+
+bool LightRay::is_beam() const { return true; }
+
+} // namespace rt

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,5 +1,5 @@
 #include "rt/Scene.hpp"
-#include "rt/Beam.hpp"
+#include "rt/LightRay.hpp"
 #include "rt/Plane.hpp"
 #include "rt/Collision.hpp"
 #include "rt/Camera.hpp"
@@ -40,7 +40,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
   }
   lights = std::move(static_lights);
 
-  std::vector<std::shared_ptr<Beam>> roots;
+  std::vector<std::shared_ptr<LightRay>> roots;
   std::vector<HittablePtr> non_beams;
   non_beams.reserve(objects.size());
   std::unordered_map<int, int> id_map;
@@ -49,7 +49,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
   {
     if (obj->is_beam())
     {
-      auto bm = std::static_pointer_cast<Beam>(obj);
+      auto bm = std::static_pointer_cast<LightRay>(obj);
       if (bm->start <= 0.0)
       {
         bm->start = 0.0;
@@ -70,10 +70,10 @@ void Scene::update_beams(const std::vector<Material> &mats)
   objects = std::move(non_beams);
   int next_oid = static_cast<int>(objects.size());
 
-  std::vector<std::shared_ptr<Beam>> to_process = roots;
+  std::vector<std::shared_ptr<LightRay>> to_process = roots;
   struct PendingLight
   {
-    std::shared_ptr<Beam> beam;
+    std::shared_ptr<LightRay> beam;
     int hit_id;
   };
   std::vector<PendingLight> pending_lights;
@@ -115,7 +115,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
         {
           Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
           Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
-          auto new_bm = std::make_shared<Beam>(
+          auto new_bm = std::make_shared<LightRay>(
               refl_orig, refl_dir, bm->radius, new_len, bm->light_intensity, 0,
               bm->material_id, new_start, bm->total_length);
           new_bm->source = bm->source;


### PR DESCRIPTION
## Summary
- Introduce Beam wrapper that builds a light ray, beam source and laser
- Rename original Beam to LightRay and update scene and parser
- Add simple Laser class and adjust material parsing for beams

## Testing
- `cmake ..` *(fails: Could not find SDL2Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bacdaf9c00832f8aa6ee76d2ceb19e