### PR TITLE
Refactor beam system into composite class

### DIFF
--- a/include/rt/Beam.hpp
+++ b/include/rt/Beam.hpp
@@ -1,28 +1,16 @@
 #pragma once
-#include "Hittable.hpp"
-#include "Ray.hpp"
+#include "BeamSource.hpp"
+#include "Laser.hpp"
+#include "LightRay.hpp"
 #include <memory>
 
-namespace rt
-{
-struct Beam : public Hittable
-{
-  Ray path;
-  double radius;
-  double length;
-  double start;
-  double total_length;
-  double light_intensity;
-  std::weak_ptr<Hittable> source;
+namespace rt {
+struct Beam {
+  std::shared_ptr<LightRay> light;
+  std::shared_ptr<Laser> laser;
+  std::shared_ptr<BeamSource> source;
   Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
-       double intensity, int oid, int mid, double start = 0.0,
-       double total = -1.0);
-
-  bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
-  bool bounding_box(AABB &out) const override;
-  bool is_beam() const override;
-  ShapeType shape_type() const override { return ShapeType::Beam; }
-  Vec3 spot_direction() const override { return path.dir; }
+       double intensity, int base_oid, int laser_mat, int big_mat,
+       int mid_mat, int small_mat);
 };
-
-} // namespace rt
+}

--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "Beam.hpp"
+#include "Laser.hpp"
 #include "Sphere.hpp"
 #include <memory>
 
@@ -9,8 +9,8 @@ struct BeamSource : public Sphere
 {
   Sphere mid;
   Sphere inner;
-  std::shared_ptr<Beam> beam;
-  BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Beam> &bm,
+  std::shared_ptr<Laser> beam;
+  BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Laser> &bm,
              double radius, int oid, int mat_big, int mat_mid, int mat_small);
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }

--- a/include/rt/Laser.hpp
+++ b/include/rt/Laser.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "Hittable.hpp"
+#include "Ray.hpp"
+#include <memory>
+
+namespace rt
+{
+struct Laser : public Hittable
+{
+  Ray path;
+  double radius;
+  double length;
+  double start;
+  double total_length;
+  double light_intensity;
+  std::weak_ptr<Hittable> source;
+  Laser(const Vec3 &origin, const Vec3 &dir, double radius, double length,
+        double intensity, int oid, int mid, double start = 0.0,
+        double total = -1.0);
+
+  bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
+  bool bounding_box(AABB &out) const override;
+  bool is_beam() const override;
+  ShapeType shape_type() const override { return ShapeType::Beam; }
+  Vec3 spot_direction() const override { return path.dir; }
+};
+
+} // namespace rt

--- a/include/rt/LightRay.hpp
+++ b/include/rt/LightRay.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "Ray.hpp"
+
+namespace rt {
+struct LightRay {
+  Ray ray;
+  double intensity;
+  LightRay(const Vec3 &origin, const Vec3 &dir, double intens)
+      : ray(origin, dir.normalized()), intensity(intens) {}
+};
+}

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -1,89 +1,15 @@
 #include "rt/Beam.hpp"
-#include <algorithm>
-#include <cmath>
 
-namespace rt
-{
-Beam::Beam(const Vec3 &origin, const Vec3 &dir, double r, double len,
-           double intensity, int oid, int mid, double s, double total)
-    : path(origin, dir.normalized()), radius(r), length(len), start(s),
-      total_length(total < 0 ? len : total), light_intensity(intensity)
-{
-  object_id = oid;
-  material_id = mid;
+namespace rt {
+Beam::Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
+           double intensity, int base_oid, int laser_mat, int big_mat,
+           int mid_mat, int small_mat) {
+  light = std::make_shared<LightRay>(origin, dir, intensity);
+  laser = std::make_shared<Laser>(origin, dir, radius, length, intensity,
+                                  base_oid, laser_mat);
+  source = std::make_shared<BeamSource>(origin, dir, laser, radius,
+                                        base_oid + 1, big_mat, mid_mat,
+                                        small_mat);
+  laser->source = source;
 }
-
-bool Beam::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
-{
-  Vec3 u = r.dir;
-  Vec3 v = path.dir;
-  Vec3 w0 = r.orig - path.orig;
-  double a = Vec3::dot(u, u);
-  double b = Vec3::dot(u, v);
-  double c = Vec3::dot(v, v);
-  double d = Vec3::dot(u, w0);
-  double e = Vec3::dot(v, w0);
-  double denom = a * c - b * b;
-
-  double sc, tc;
-  if (std::fabs(denom) < 1e-9)
-  {
-    sc = -d / a;
-    tc = (a * e - b * d) / (a * c);
-  }
-  else
-  {
-    sc = (b * e - c * d) / denom;
-    tc = (a * e - b * d) / denom;
-  }
-
-  if (sc < tmin || sc > tmax)
-    return false;
-  if (tc < 0.0 || tc > length)
-    return false;
-
-  Vec3 pr = r.at(sc);
-  Vec3 pb = path.at(tc);
-  Vec3 diff = pr - pb;
-  double dist2 = diff.length_squared();
-  if (dist2 > radius * radius)
-    return false;
-
-  Vec3 outward;
-  if (dist2 > 1e-12)
-  {
-    outward = diff.normalized();
-  }
-  else
-  {
-    outward = Vec3::cross(path.dir, Vec3(1, 0, 0));
-    if (outward.length_squared() < 1e-12)
-      outward = Vec3::cross(path.dir, Vec3(0, 1, 0));
-    outward = outward.normalized();
-  }
-
-  rec.t = sc;
-  rec.p = pr;
-  rec.object_id = object_id;
-  rec.material_id = material_id;
-  rec.beam_ratio = (start + tc) / total_length;
-  rec.set_face_normal(r, outward);
-  return true;
-}
-
-bool Beam::bounding_box(AABB &out) const
-{
-  Vec3 start = path.orig;
-  Vec3 end = path.at(length);
-  Vec3 min(std::min(start.x, end.x), std::min(start.y, end.y),
-           std::min(start.z, end.z));
-  Vec3 max(std::max(start.x, end.x), std::max(start.y, end.y),
-           std::max(start.z, end.z));
-  Vec3 ex(radius, radius, radius);
-  out = AABB(min - ex, max + ex);
-  return true;
-}
-
-bool Beam::is_beam() const { return true; }
-
 } // namespace rt

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -4,8 +4,8 @@
 namespace rt
 {
 BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
-                       const std::shared_ptr<Beam> &bm, double radius, int oid,
-                       int mat_big, int mat_mid, int mat_small)
+                       const std::shared_ptr<Laser> &bm, double radius,
+                       int oid, int mat_big, int mat_mid, int mat_small)
     : Sphere(c, radius * (4.0 / 3.0) * (4.0 / 3.0), oid, mat_big),
       mid(c, radius * (4.0 / 3.0), -oid - 1, mat_mid),
       inner(c, radius, -oid - 2, mat_small), beam(bm)

--- a/src/Laser.cpp
+++ b/src/Laser.cpp
@@ -1,0 +1,89 @@
+#include "rt/Laser.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace rt
+{
+Laser::Laser(const Vec3 &origin, const Vec3 &dir, double r, double len,
+             double intensity, int oid, int mid, double s, double total)
+    : path(origin, dir.normalized()), radius(r), length(len), start(s),
+      total_length(total < 0 ? len : total), light_intensity(intensity)
+{
+  object_id = oid;
+  material_id = mid;
+}
+
+bool Laser::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
+{
+  Vec3 u = r.dir;
+  Vec3 v = path.dir;
+  Vec3 w0 = r.orig - path.orig;
+  double a = Vec3::dot(u, u);
+  double b = Vec3::dot(u, v);
+  double c = Vec3::dot(v, v);
+  double d = Vec3::dot(u, w0);
+  double e = Vec3::dot(v, w0);
+  double denom = a * c - b * b;
+
+  double sc, tc;
+  if (std::fabs(denom) < 1e-9)
+  {
+    sc = -d / a;
+    tc = (a * e - b * d) / (a * c);
+  }
+  else
+  {
+    sc = (b * e - c * d) / denom;
+    tc = (a * e - b * d) / denom;
+  }
+
+  if (sc < tmin || sc > tmax)
+    return false;
+  if (tc < 0.0 || tc > length)
+    return false;
+
+  Vec3 pr = r.at(sc);
+  Vec3 pb = path.at(tc);
+  Vec3 diff = pr - pb;
+  double dist2 = diff.length_squared();
+  if (dist2 > radius * radius)
+    return false;
+
+  Vec3 outward;
+  if (dist2 > 1e-12)
+  {
+    outward = diff.normalized();
+  }
+  else
+  {
+    outward = Vec3::cross(path.dir, Vec3(1, 0, 0));
+    if (outward.length_squared() < 1e-12)
+      outward = Vec3::cross(path.dir, Vec3(0, 1, 0));
+    outward = outward.normalized();
+  }
+
+  rec.t = sc;
+  rec.p = pr;
+  rec.object_id = object_id;
+  rec.material_id = material_id;
+  rec.beam_ratio = (start + tc) / total_length;
+  rec.set_face_normal(r, outward);
+  return true;
+}
+
+bool Laser::bounding_box(AABB &out) const
+{
+  Vec3 start = path.orig;
+  Vec3 end = path.at(length);
+  Vec3 min(std::min(start.x, end.x), std::min(start.y, end.y),
+           std::min(start.z, end.z));
+  Vec3 max(std::max(start.x, end.x), std::max(start.y, end.y),
+           std::max(start.z, end.z));
+  Vec3 ex(radius, radius, radius);
+  out = AABB(min - ex, max + ex);
+  return true;
+}
+
+bool Laser::is_beam() const { return true; }
+
+} // namespace rt

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1,6 +1,5 @@
 #include "rt/Parser.hpp"
 #include "rt/Beam.hpp"
-#include "rt/BeamSource.hpp"
 #include "rt/Cube.hpp"
 #include "rt/Cone.hpp"
 #include "rt/Cylinder.hpp"
@@ -301,8 +300,6 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         int beam_mat = mid++;
 
         Vec3 dir_norm = dir.normalized();
-        auto bm = std::make_shared<Beam>(o, dir_norm, g, L, intensity,
-                                         oid++, beam_mat);
 
         materials.emplace_back();
         materials.back().color = Vec3(1.0, 1.0, 1.0);
@@ -322,17 +319,18 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         materials.back().alpha = 1.0;
         int small_mat = mid++;
 
-        auto src = std::make_shared<BeamSource>(o, dir_norm, bm, g, oid++,
-                                                big_mat, mid_mat, small_mat);
-        src->movable = (s_move == "M");
-        bm->source = src;
-        outScene.objects.push_back(bm);
-        outScene.objects.push_back(src);
+        auto bm = std::make_shared<Beam>(o, dir_norm, g, L, intensity, oid,
+                                         beam_mat, big_mat, mid_mat, small_mat);
+        oid += 2;
+        bm->source->movable = (s_move == "M");
+        outScene.objects.push_back(bm->laser);
+        outScene.objects.push_back(bm->source);
         const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
         outScene.lights.emplace_back(
             o, unit, intensity,
-            std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
-            src->object_id, dir_norm, cone_cos, L);
+            std::vector<int>{bm->laser->object_id, bm->source->object_id,
+                             bm->source->mid.object_id},
+            bm->source->object_id, dir_norm, cone_cos, L);
       }
     }
     else if (id == "co")
@@ -414,7 +412,7 @@ bool Parser::save_rt_file(const std::string &path, const Scene &scene,
   {
     if (obj->is_beam())
     {
-      auto bm = std::static_pointer_cast<Beam>(obj);
+      auto bm = std::static_pointer_cast<Laser>(obj);
       if (bm->start > 0.0)
         continue;
       if (auto src = bm->source.lock())

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,5 +1,5 @@
 #include "rt/Scene.hpp"
-#include "rt/Beam.hpp"
+#include "rt/Laser.hpp"
 #include "rt/Plane.hpp"
 #include "rt/Collision.hpp"
 #include "rt/Camera.hpp"
@@ -40,7 +40,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
   }
   lights = std::move(static_lights);
 
-  std::vector<std::shared_ptr<Beam>> roots;
+  std::vector<std::shared_ptr<Laser>> roots;
   std::vector<HittablePtr> non_beams;
   non_beams.reserve(objects.size());
   std::unordered_map<int, int> id_map;
@@ -49,7 +49,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
   {
     if (obj->is_beam())
     {
-      auto bm = std::static_pointer_cast<Beam>(obj);
+      auto bm = std::static_pointer_cast<Laser>(obj);
       if (bm->start <= 0.0)
       {
         bm->start = 0.0;
@@ -70,10 +70,10 @@ void Scene::update_beams(const std::vector<Material> &mats)
   objects = std::move(non_beams);
   int next_oid = static_cast<int>(objects.size());
 
-  std::vector<std::shared_ptr<Beam>> to_process = roots;
+  std::vector<std::shared_ptr<Laser>> to_process = roots;
   struct PendingLight
   {
-    std::shared_ptr<Beam> beam;
+    std::shared_ptr<Laser> beam;
     int hit_id;
   };
   std::vector<PendingLight> pending_lights;
@@ -115,7 +115,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
         {
           Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
           Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
-          auto new_bm = std::make_shared<Beam>(
+          auto new_bm = std::make_shared<Laser>(
               refl_orig, refl_dir, bm->radius, new_len, bm->light_intensity, 0,
               bm->material_id, new_start, bm->total_length);
           new_bm->source = bm->source;


### PR DESCRIPTION
## Summary
- Introduce new `LightRay` struct and rename the previous `Beam` shape to `Laser`.
- Add a composite `Beam` class that bundles a `BeamSource`, `Laser`, and `LightRay` for easier creation of beam objects.
- Update parsing and scene logic to construct and process the new beam structure.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68bacdaf9c00832f8aa6ee76d2ceb19e