### PR TITLE
Refactor long scene and parser routines

### DIFF
--- a/inc/Renderer.hpp
+++ b/inc/Renderer.hpp
@@ -5,6 +5,10 @@
 #include <string>
 #include <vector>
 
+struct SDL_Window;
+struct SDL_Renderer;
+struct SDL_Texture;
+
 class RenderSettings
 {
 	public:
@@ -18,11 +22,25 @@ class Renderer
 {
 	public:
 	Renderer(Scene &s, Camera &c);
-	void render_ppm(const std::string &path, const std::vector<Material> &mats,
-					const RenderSettings &rset);
-	void render_window(std::vector<Material> &mats, const RenderSettings &rset,
-					   const std::string &scene_path);
-	private:
-	Scene &scene;
-	Camera &cam;
+        void render_ppm(const std::string &path, const std::vector<Material> &mats,
+                                        const RenderSettings &rset);
+        void render_window(std::vector<Material> &mats, const RenderSettings &rset,
+                                           const std::string &scene_path);
+        private:
+        struct RenderState;
+        bool init_sdl(SDL_Window *&win, SDL_Renderer *&ren, SDL_Texture *&tex,
+                                       int W, int H, int RW, int RH);
+        void process_events(RenderState &st, SDL_Window *win, int W, int H,
+                                               std::vector<Material> &mats,
+                                               const std::string &scene_path);
+        void handle_keyboard(RenderState &st, double dt,
+                                               std::vector<Material> &mats);
+        void update_selection(RenderState &st, std::vector<Material> &mats);
+        void render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex,
+                                          std::vector<Vec3> &framebuffer,
+                                          std::vector<unsigned char> &pixels, int RW,
+                                          int RH, int W, int H, int T,
+                                          std::vector<Material> &mats);
+        Scene &scene;
+        Camera &cam;
 };

--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -5,8 +5,10 @@
 #include "material.hpp"
 #include <memory>
 #include <vector>
+#include <unordered_map>
 
 class Camera;
+class Laser;
 
 class Scene
 {
@@ -16,8 +18,8 @@ class Scene
 	Ambient ambient{Vec3(1, 1, 1), 0.0};
 	std::shared_ptr<Hittable> accel;
 
-	// Update beam objects and associated lights in the scene.
-	void update_beams(const std::vector<Material> &materials);
+        // Update beam objects and associated lights in the scene.
+        void update_beams(const std::vector<Material> &materials);
 
 	// Build bounding volume hierarchy for static geometry.
 	void build_bvh();
@@ -32,10 +34,16 @@ class Scene
 	Vec3 move_with_collision(int index, const Vec3 &delta);
 
 	// Move camera while avoiding obstacles.
-	Vec3 move_camera(Camera &cam, const Vec3 &delta,
-					 const std::vector<Material> &materials) const;
-	private:
-	bool is_movable(int index) const;
-	void apply_translation(const HittablePtr &object, const Vec3 &delta);
-	void attempt_axis_move(int index, const Vec3 &axis_delta, Vec3 &moved);
+        Vec3 move_camera(Camera &cam, const Vec3 &delta,
+                                         const std::vector<Material> &materials) const;
+        private:
+        bool is_movable(int index) const;
+        void apply_translation(const HittablePtr &object, const Vec3 &delta);
+        void attempt_axis_move(int index, const Vec3 &axis_delta, Vec3 &moved);
+        void prepare_beam_roots(std::vector<std::shared_ptr<Laser>> &roots,
+                                                        std::unordered_map<int, int> &id_map);
+        void process_beams(const std::vector<Material> &mats,
+                                               std::vector<std::shared_ptr<Laser>> &roots,
+                                               std::unordered_map<int, int> &id_map);
+        void remap_light_ids(const std::unordered_map<int, int> &id_map);
 };


### PR DESCRIPTION
## Summary
- Break Scene::update_beams into focused helpers for beam preparation, processing, and light remapping
- Split Parser::parse_rt_file into dedicated parsing helpers for each object type

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68baf558254c832fb399ab035b8597c4