### PR TITLE
Refactor beam radius handling and source scaling

### DIFF
--- a/inc/Beam.hpp
+++ b/inc/Beam.hpp
@@ -7,10 +7,10 @@
 class Beam
 {
 	public:
-	std::shared_ptr<LightRay> light;
-	std::shared_ptr<Laser> laser;
-	std::shared_ptr<BeamSource> source;
-	Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
-		 double intensity, int base_oid, int laser_mat, int big_mat,
-		 int mid_mat, int small_mat);
+       std::shared_ptr<LightRay> light;
+       std::shared_ptr<Laser> laser;
+       std::shared_ptr<BeamSource> source;
+       Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
+                double length, double intensity, int base_oid, int laser_mat,
+                int big_mat, int mid_mat, int small_mat);
 };

--- a/inc/BeamSource.hpp
+++ b/inc/BeamSource.hpp
@@ -8,9 +8,10 @@ class BeamSource : public Sphere
 	public:
 	Sphere mid;
 	Sphere inner;
-	std::shared_ptr<Laser> beam;
-	BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Laser> &bm,
-			   double radius, int oid, int mat_big, int mat_mid, int mat_small);
+       std::shared_ptr<Laser> beam;
+       BeamSource(const Vec3 &c, const Vec3 &dir,
+                          const std::shared_ptr<Laser> &bm, double mid_radius,
+                          int oid, int mat_big, int mat_mid, int mat_small);
 	bool hit(const Ray &r, double tmin, double tmax,
 			 HitRecord &rec) const override;
 	bool bounding_box(AABB &out) const override

--- a/inc/Laser.hpp
+++ b/inc/Laser.hpp
@@ -6,16 +6,15 @@
 class Laser : public Hittable
 {
 	public:
-	Ray path;
-	double radius;
-	double length;
+       Ray path;
+       const double radius;
+       double length;
 	double start;
 	double total_length;
 	double light_intensity;
 	std::weak_ptr<Hittable> source;
-	Laser(const Vec3 &origin, const Vec3 &dir, double radius, double length,
-		  double intensity, int oid, int mid, double start = 0.0,
-		  double total = -1.0);
+       Laser(const Vec3 &origin, const Vec3 &dir, double length, double intensity,
+                 int oid, int mid, double start = 0.0, double total = -1.0);
 
 	bool hit(const Ray &r, double tmin, double tmax,
 			 HitRecord &rec) const override;

--- a/inc/LightRay.hpp
+++ b/inc/LightRay.hpp
@@ -3,11 +3,12 @@
 
 class LightRay
 {
-	public:
-	Ray ray;
-	double intensity;
-	LightRay(const Vec3 &origin, const Vec3 &dir, double intens)
-		: ray(origin, dir.normalized()), intensity(intens)
-	{
-	}
+        public:
+        Ray ray;
+       double radius;
+       double intensity;
+       LightRay(const Vec3 &origin, const Vec3 &dir, double r, double intens)
+               : ray(origin, dir.normalized()), radius(r), intensity(intens)
+       {
+       }
 };

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -1,13 +1,14 @@
 #include "Beam.hpp"
 
-Beam::Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
-		   double intensity, int base_oid, int laser_mat, int big_mat,
-		   int mid_mat, int small_mat)
+Beam::Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
+                  double length, double intensity, int base_oid, int laser_mat,
+                  int big_mat, int mid_mat, int small_mat)
 {
-	light = std::make_shared<LightRay>(origin, dir, intensity);
-	laser = std::make_shared<Laser>(origin, dir, radius, length, intensity,
-									base_oid, laser_mat);
-	source = std::make_shared<BeamSource>(
-		origin, dir, laser, radius, base_oid + 1, big_mat, mid_mat, small_mat);
-	laser->source = source;
+       light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity);
+       laser = std::make_shared<Laser>(origin, dir, length, intensity, base_oid,
+                                                                       laser_mat);
+       source = std::make_shared<BeamSource>(
+               origin, dir, laser, ray_radius, base_oid + 1, big_mat, mid_mat,
+               small_mat);
+       laser->source = source;
 }

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -2,13 +2,13 @@
 #include <cmath>
 
 BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
-					   const std::shared_ptr<Laser> &bm, double radius, int oid,
-					   int mat_big, int mat_mid, int mat_small)
-	: Sphere(c, radius * (4.0 / 3.0) * (4.0 / 3.0), oid, mat_big),
-	  mid(c, radius * (4.0 / 3.0), -oid - 1, mat_mid),
-	  inner(c, radius, -oid - 2, mat_small), beam(bm)
+                                           const std::shared_ptr<Laser> &bm, double mid_radius,
+                                           int oid, int mat_big, int mat_mid, int mat_small)
+       : Sphere(c, mid_radius * 2.0, oid, mat_big),
+         mid(c, mid_radius, -oid - 1, mat_mid),
+         inner(c, mid_radius * 0.5, -oid - 2, mat_small), beam(bm)
 {
-	(void)dir;
+        (void)dir;
 }
 
 bool BeamSource::hit(const Ray &r, double tmin, double tmax,

--- a/src/Laser.cpp
+++ b/src/Laser.cpp
@@ -2,13 +2,13 @@
 #include <algorithm>
 #include <cmath>
 
-Laser::Laser(const Vec3 &origin, const Vec3 &dir, double r, double len,
-			 double intensity, int oid, int mid, double s, double total)
-	: path(origin, dir.normalized()), radius(r), length(len), start(s),
-	  total_length(total < 0 ? len : total), light_intensity(intensity)
+Laser::Laser(const Vec3 &origin, const Vec3 &dir, double len,
+                         double intensity, int oid, int mid, double s, double total)
+       : path(origin, dir.normalized()), radius(0.1), length(len), start(s),
+         total_length(total < 0 ? len : total), light_intensity(intensity)
 {
-	object_id = oid;
-	material_id = mid;
+        object_id = oid;
+        material_id = mid;
 }
 
 bool Laser::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -267,17 +267,17 @@ static void parse_cube(std::istringstream &iss, Scene &scene, int &oid, int &mid
 static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid,
                                             std::vector<Material> &mats)
 {
-        std::string s_intens, s_pos, s_dir, s_rgb, s_g, s_L;
-        iss >> s_intens >> s_pos >> s_dir >> s_rgb >> s_g >> s_L;
+       std::string s_intens, s_pos, s_dir, s_rgb, s_r, s_L;
+       iss >> s_intens >> s_pos >> s_dir >> s_rgb >> s_r >> s_L;
         std::string s_move;
         if (!(iss >> s_move))
                 s_move = "IM";
-        Vec3 o, dir, rgb;
-        double g = 0.1, L = 1.0, intensity = 0.75;
+       Vec3 o, dir, rgb;
+       double ray_radius = 0.1, L = 1.0, intensity = 0.75;
         double a = 255;
-        if (to_double(s_intens, intensity) && parse_triple(s_pos, o) &&
-                parse_triple(s_dir, dir) && parse_rgba(s_rgb, rgb, a) &&
-                to_double(s_g, g) && to_double(s_L, L))
+       if (to_double(s_intens, intensity) && parse_triple(s_pos, o) &&
+               parse_triple(s_dir, dir) && parse_rgba(s_rgb, rgb, a) &&
+               to_double(s_r, ray_radius) && to_double(s_L, L))
         {
                 Vec3 unit = rgb_to_unit(rgb);
                 mats.emplace_back();
@@ -307,9 +307,9 @@ static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid
                 mats.back().alpha = 1.0;
                 int small_mat = mid++;
 
-                auto bm = std::make_shared<Beam>(o, dir_norm, g, L, intensity,
-                                                                                         oid, beam_mat, big_mat,
-                                                                                         mid_mat, small_mat);
+               auto bm = std::make_shared<Beam>(o, dir_norm, ray_radius, L,
+                                                                                        intensity, oid, beam_mat,
+                                                                                        big_mat, mid_mat, small_mat);
                 oid += 2;
                 bm->source->movable = (s_move == "M");
                 scene.objects.push_back(bm->laser);

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -117,10 +117,10 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                 {
                                         Vec3 refl_dir = reflect(forward.dir, hit_rec.normal);
                                         Vec3 refl_orig = forward.at(closest) + refl_dir * 1e-4;
-                                        auto new_bm = std::make_shared<Laser>(
-                                                refl_orig, refl_dir, bm->radius, new_len,
-                                                bm->light_intensity, 0, bm->material_id, new_start,
-                                                bm->total_length);
+                                       auto new_bm = std::make_shared<Laser>(
+                                               refl_orig, refl_dir, new_len,
+                                               bm->light_intensity, 0, bm->material_id,
+                                               new_start, bm->total_length);
                                         new_bm->source = bm->source;
                                         to_process.push_back(new_bm);
                                         pending_lights.push_back({new_bm, hit_rec.object_id});


### PR DESCRIPTION
## Summary
- Fix laser radius at 0.1 regardless of scene file input
- Interpret `bm` line radius parameter as light ray and middle sphere radius
- Scale beam source spheres: inner half and outer double the middle sphere

## Testing
- `cmake .. && make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68bda74ff248832f8962a811844e1f42