### PR TITLE
Reflect light rays during beam updates

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "BVH.hpp"
 #include "Hittable.hpp"
+#include "LightRay.hpp"
 #include "light.hpp"
 #include "material.hpp"
 #include <memory>
@@ -13,8 +14,9 @@ class Laser;
 class Scene
 {
 	public:
-	std::vector<HittablePtr> objects;
-	std::vector<PointLight> lights;
+        std::vector<HittablePtr> objects;
+        std::vector<PointLight> lights;
+        std::vector<LightRay> light_rays;
 	Ambient ambient{Vec3(1, 1, 1), 0.0};
 	std::shared_ptr<Hittable> accel;
 

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -141,6 +141,19 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                                         bm->light_intensity * ratio,
                                                         std::vector<int>{bm->object_id, pl.hit_id},
                                                         bm->object_id, bm->path.dir, cone_cos, bm->length);
+                light_rays.emplace_back(bm->path.orig, bm->path.dir,
+                                                        bm->radius,
+                                                        bm->light_intensity * ratio);
+        }
+
+        for (const auto &root : roots)
+        {
+                double remain = root->total_length - root->start;
+                double ratio =
+                        (root->total_length > 0.0) ? remain / root->total_length : 0.0;
+                light_rays.emplace_back(root->path.orig, root->path.dir,
+                                                        root->radius,
+                                                        root->light_intensity * ratio);
         }
 }
 
@@ -174,6 +187,7 @@ void Scene::remap_light_ids(const std::unordered_map<int, int> &id_map)
 // Remove finished beam segments and spawn new beams for reflections.
 void Scene::update_beams(const std::vector<Material> &mats)
 {
+        light_rays.clear();
         std::vector<std::shared_ptr<Laser>> roots;
         std::unordered_map<int, int> id_map;
         prepare_beam_roots(roots, id_map);


### PR DESCRIPTION
## Summary
- track light ray segments in `Scene`
- spawn light rays for reflected and root beams
- clear outdated light rays before recalculating beams

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4`


------
https://chatgpt.com/codex/tasks/task_e_68bde109dac8832f8e002b47e4be010b