### PR TITLE
Reflect light rays

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "BVH.hpp"
 #include "Hittable.hpp"
+#include "LightRay.hpp"
 #include "light.hpp"
 #include "material.hpp"
 #include <memory>
@@ -14,7 +15,8 @@ class Scene
 {
 	public:
 	std::vector<HittablePtr> objects;
-	std::vector<PointLight> lights;
+        std::vector<PointLight> lights;
+        std::vector<LightRay> light_rays;
 	Ambient ambient{Vec3(1, 1, 1), 0.0};
 	std::shared_ptr<Hittable> accel;
 

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -314,6 +314,7 @@ static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid
                 bm->source->movable = (s_move == "M");
                 scene.objects.push_back(bm->laser);
                 scene.objects.push_back(bm->source);
+                scene.light_rays.push_back(*bm->light);
                 const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
                 scene.lights.emplace_back(
                         o, unit, intensity,

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -87,6 +87,8 @@ void Scene::process_beams(const std::vector<Material> &mats,
                         id_map[bm->object_id] = next_oid;
                 bm->object_id = next_oid++;
                 objects.push_back(bm);
+                light_rays.emplace_back(bm->path.orig, bm->path.dir, bm->radius,
+                                                          bm->light_intensity);
 
                 Ray forward(bm->path.orig, bm->path.dir);
                 HitRecord tmp, hit_rec;
@@ -174,6 +176,7 @@ void Scene::remap_light_ids(const std::unordered_map<int, int> &id_map)
 // Remove finished beam segments and spawn new beams for reflections.
 void Scene::update_beams(const std::vector<Material> &mats)
 {
+        light_rays.clear();
         std::vector<std::shared_ptr<Laser>> roots;
         std::unordered_map<int, int> id_map;
         prepare_beam_roots(roots, id_map);


### PR DESCRIPTION
## Summary
- track light rays alongside lasers and clear/repopulate them when beams update
- register root light rays on parsing and spawn new ones for reflected beams

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68bde109dac8832f8e002b47e4be010b