### PR TITLE
Revamp main menu with colorful title and extra options

### DIFF
--- a/inc/Leaderboard.hpp
+++ b/inc/Leaderboard.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+class Leaderboard
+{
+        public:
+        static void show();
+};

--- a/inc/Settings.hpp
+++ b/inc/Settings.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+class Settings
+{
+        public:
+        static void show();
+};

--- a/src/Leaderboard.cpp
+++ b/src/Leaderboard.cpp
@@ -1,0 +1,6 @@
+#include "Leaderboard.hpp"
+
+void Leaderboard::show()
+{
+        // TODO: implement leaderboard screen
+}

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -6,44 +6,74 @@ namespace
 {
 const uint8_t *get_glyph(char character)
 {
-	switch (character)
-	{
-	case 'A':
-	{
-		static const uint8_t data[7] = {0x0E, 0x11, 0x11, 0x1F,
-										0x11, 0x11, 0x11};
-		return data;
-	}
-	case 'E':
-	{
-		static const uint8_t data[7] = {0x1F, 0x10, 0x10, 0x1E,
-										0x10, 0x10, 0x1F};
-		return data;
-	}
-	case 'G':
-	{
-		static const uint8_t data[7] = {0x0F, 0x10, 0x10, 0x13,
-										0x11, 0x11, 0x0F};
-		return data;
-	}
-	case 'I':
-	{
-		static const uint8_t data[7] = {0x1F, 0x04, 0x04, 0x04,
-										0x04, 0x04, 0x1F};
-		return data;
-	}
-	case 'L':
-	{
-		static const uint8_t data[7] = {0x10, 0x10, 0x10, 0x10,
-										0x10, 0x10, 0x1F};
-		return data;
-	}
-	case 'N':
-	{
-		static const uint8_t data[7] = {0x11, 0x19, 0x15, 0x13,
-										0x11, 0x11, 0x11};
-		return data;
-	}
+        switch (character)
+        {
+        case 'A':
+        {
+                static const uint8_t data[7] = {0x0E, 0x11, 0x11, 0x1F,
+                                                                                0x11, 0x11, 0x11};
+                return data;
+        }
+        case 'B':
+        {
+                static const uint8_t data[7] = {0x1E, 0x11, 0x11, 0x1E,
+                                                                                0x11, 0x11, 0x1E};
+                return data;
+        }
+        case 'D':
+        {
+                static const uint8_t data[7] = {0x1C, 0x12, 0x11, 0x11,
+                                                                                0x11, 0x12, 0x1C};
+                return data;
+        }
+        case 'E':
+        {
+                static const uint8_t data[7] = {0x1F, 0x10, 0x10, 0x1E,
+                                                                                0x10, 0x10, 0x1F};
+                return data;
+        }
+        case 'G':
+        {
+                static const uint8_t data[7] = {0x0F, 0x10, 0x10, 0x13,
+                                                                                0x11, 0x11, 0x0F};
+                return data;
+        }
+        case 'H':
+        {
+                static const uint8_t data[7] = {0x11, 0x11, 0x11, 0x1F,
+                                                                                0x11, 0x11, 0x11};
+                return data;
+        }
+        case 'I':
+        {
+                static const uint8_t data[7] = {0x1F, 0x04, 0x04, 0x04,
+                                                                                0x04, 0x04, 0x1F};
+                return data;
+        }
+        case 'M':
+        {
+                static const uint8_t data[7] = {0x11, 0x1B, 0x15, 0x11,
+                                                                                0x11, 0x11, 0x11};
+                return data;
+        }
+        case 'L':
+        {
+                static const uint8_t data[7] = {0x10, 0x10, 0x10, 0x10,
+                                                                                0x10, 0x10, 0x1F};
+                return data;
+        }
+        case 'N':
+        {
+                static const uint8_t data[7] = {0x11, 0x19, 0x15, 0x13,
+                                                                                0x11, 0x11, 0x11};
+                return data;
+        }
+        case 'O':
+        {
+                static const uint8_t data[7] = {0x0E, 0x11, 0x11, 0x11,
+                                                                                0x11, 0x11, 0x0E};
+                return data;
+        }
         case 'P':
         {
                 static const uint8_t data[7] = {0x1E, 0x11, 0x11, 0x1E,
@@ -54,6 +84,12 @@ const uint8_t *get_glyph(char character)
         {
                 static const uint8_t data[7] = {0x0E, 0x11, 0x11, 0x11,
                                                                                 0x11, 0x13, 0x0F};
+                return data;
+        }
+        case 'R':
+        {
+                static const uint8_t data[7] = {0x1E, 0x11, 0x11, 0x1E,
+                                                                                0x14, 0x12, 0x11};
                 return data;
         }
         case 'S':
@@ -151,19 +187,30 @@ bool MainMenu::show(int width, int height)
         button_width = 300;
         int button_height;
         button_height = 100;
+        int title_scale;
+        title_scale = 4;
+        int title_height;
+        title_height = 7 * title_scale;
         int margin;
-        margin = (height - 3 * button_height) / 4;
+        margin = (height - title_height - 4 * button_height) / 6;
+        int title_y;
+        title_y = margin;
         SDL_Rect play_rect;
-        play_rect = {width / 2 - button_width / 2, margin, button_width,
+        play_rect = {width / 2 - button_width / 2,
+                                  title_y + title_height + margin, button_width,
                                   button_height};
+        SDL_Rect leaderboard_rect;
+        leaderboard_rect = {width / 2 - button_width / 2,
+                                         play_rect.y + button_height + margin,
+                                         button_width, button_height};
         SDL_Rect settings_rect;
         settings_rect = {width / 2 - button_width / 2,
-                                         margin * 2 + button_height, button_width,
-                                         button_height};
+                                         leaderboard_rect.y + button_height + margin,
+                                         button_width, button_height};
         SDL_Rect quit_rect;
         quit_rect = {width / 2 - button_width / 2,
-                                      margin * 3 + 2 * button_height, button_width,
-                                      button_height};
+                                      settings_rect.y + button_height + margin,
+                                      button_width, button_height};
         bool running;
         running = true;
 	bool play_selected;
@@ -208,6 +255,11 @@ bool MainMenu::show(int width, int height)
 		hover_play =
 			mouse_x >= play_rect.x && mouse_x < play_rect.x + play_rect.w &&
 			mouse_y >= play_rect.y && mouse_y < play_rect.y + play_rect.h;
+                bool hover_leaderboard;
+                hover_leaderboard = mouse_x >= leaderboard_rect.x &&
+                                                     mouse_x < leaderboard_rect.x + leaderboard_rect.w &&
+                                                     mouse_y >= leaderboard_rect.y &&
+                                                     mouse_y < leaderboard_rect.y + leaderboard_rect.h;
                 bool hover_settings;
                 hover_settings = mouse_x >= settings_rect.x &&
                                                  mouse_x < settings_rect.x + settings_rect.w &&
@@ -220,33 +272,91 @@ bool MainMenu::show(int width, int height)
                                          mouse_y < quit_rect.y + quit_rect.h;
                 SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
                 SDL_RenderClear(renderer);
+                SDL_Color white;
+                white = {255, 255, 255, 255};
+                // Draw title
+                std::string title;
+                title = "MINIRT THE GAME";
+                int title_width;
+                title_width = text_width(title, title_scale);
+                int title_x;
+                title_x = width / 2 - title_width / 2;
+                int x;
+                x = title_x;
+                int index;
+                index = 0;
+                for (char c : title)
+                {
+                        SDL_Color color;
+                        color = white;
+                        if (c != ' ' && index < 6)
+                        {
+                                switch (index)
+                                {
+                                case 0:
+                                        color = {0, 0, 255, 255};
+                                        break;
+                                case 1:
+                                        color = {255, 255, 0, 255};
+                                        break;
+                                case 2:
+                                        color = {0, 255, 0, 255};
+                                        break;
+                                case 3:
+                                        color = {255, 0, 0, 255};
+                                        break;
+                                case 4:
+                                        color = {0, 255, 255, 255};
+                                        break;
+                                case 5:
+                                        color = {128, 0, 128, 255};
+                                        break;
+                                }
+                                ++index;
+                        }
+                        draw_character(renderer, c, x, title_y, color, title_scale);
+                        x += (5 + 1) * title_scale;
+                }
+                // Draw buttons
                 SDL_Color fill;
-                fill =
-                        hover_play ? SDL_Color{0, 128, 128, 255} : SDL_Color{0, 0, 0, 255};
-		SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
-		SDL_RenderFillRect(renderer, &play_rect);
-		SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
-		SDL_RenderDrawRect(renderer, &play_rect);
-		int scale;
-		scale = 4;
-		SDL_Color white;
-		white = {255, 255, 255, 255};
-		int text_x;
-		int text_y;
-		text_x = play_rect.x + (play_rect.w - text_width("PLAY", scale)) / 2;
-		text_y = play_rect.y + (play_rect.h - 7 * scale) / 2;
-		draw_text(renderer, "PLAY", text_x, text_y, white, scale);
-		fill = hover_settings ? SDL_Color{0, 128, 128, 255}
-							  : SDL_Color{0, 0, 0, 255};
-		SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
-		SDL_RenderFillRect(renderer, &settings_rect);
-		SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+                int scale;
+                scale = 4;
+                int text_x;
+                int text_y;
+                // Play button
+                fill = hover_play ? SDL_Color{0, 255, 0, 255}
+                                                    : SDL_Color{0, 0, 0, 255};
+                SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+                SDL_RenderFillRect(renderer, &play_rect);
+                SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+                SDL_RenderDrawRect(renderer, &play_rect);
+                text_x = play_rect.x + (play_rect.w - text_width("PLAY", scale)) / 2;
+                text_y = play_rect.y + (play_rect.h - 7 * scale) / 2;
+                draw_text(renderer, "PLAY", text_x, text_y, white, scale);
+                // Leaderboard button
+                fill = hover_leaderboard ? SDL_Color{0, 0, 255, 255}
+                                                            : SDL_Color{0, 0, 0, 255};
+                SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+                SDL_RenderFillRect(renderer, &leaderboard_rect);
+                SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+                SDL_RenderDrawRect(renderer, &leaderboard_rect);
+                text_x = leaderboard_rect.x +
+                                 (leaderboard_rect.w - text_width("LEADERBOARD", scale)) / 2;
+                text_y = leaderboard_rect.y + (leaderboard_rect.h - 7 * scale) / 2;
+                draw_text(renderer, "LEADERBOARD", text_x, text_y, white, scale);
+                // Settings button
+                fill = hover_settings ? SDL_Color{255, 255, 0, 255}
+                                                          : SDL_Color{0, 0, 0, 255};
+                SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+                SDL_RenderFillRect(renderer, &settings_rect);
+                SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
                 SDL_RenderDrawRect(renderer, &settings_rect);
                 text_x = settings_rect.x +
                                  (settings_rect.w - text_width("SETTINGS", scale)) / 2;
                 text_y = settings_rect.y + (settings_rect.h - 7 * scale) / 2;
                 draw_text(renderer, "SETTINGS", text_x, text_y, white, scale);
-                fill = hover_quit ? SDL_Color{0, 128, 128, 255}
+                // Quit button
+                fill = hover_quit ? SDL_Color{255, 0, 0, 255}
                                                   : SDL_Color{0, 0, 0, 255};
                 SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
                 SDL_RenderFillRect(renderer, &quit_rect);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,0 +1,6 @@
+#include "Settings.hpp"
+
+void Settings::show()
+{
+        // TODO: implement settings screen
+}


### PR DESCRIPTION
## Summary
- add color-per-letter title for "MINIRT THE GAME"
- expand main menu with Leaderboard and Settings buttons with unique hover highlights
- provide empty Leaderboard and Settings class templates for future features

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68c12e426ae4832fa02b84df5c15892c