### PR TITLE
Add settings menu with sliders and persistent configuration

### DIFF
--- a/inc/ButtonsCluster.hpp
+++ b/inc/ButtonsCluster.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <SDL.h>
+#include <string>
+#include <vector>
+
+class ButtonsCluster {
+public:
+    struct Item {
+        std::string text;
+        SDL_Rect rect{0,0,0,0};
+    };
+
+    std::vector<Item> items;
+    int selected = 0;
+
+    void add(const std::string &text);
+    void set_layout(int x, int y, int total_w, int h, int gap);
+    void handle_event(const SDL_Event &e);
+    void draw(SDL_Renderer *renderer, int scale) const;
+    std::string current_text() const;
+};

--- a/inc/Settings.hpp
+++ b/inc/Settings.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <string>
+
+struct GameSettings {
+    char quality = 'H';
+    double mouse_sensitivity = 1.0; // multiplier
+    int width = 1080;
+    int height = 720;
+};
+
+extern GameSettings g_settings;
+
+bool load_settings(const std::string &path = "settings.yaml");
+bool save_settings(const std::string &path = "settings.yaml");

--- a/inc/SettingsMenu.hpp
+++ b/inc/SettingsMenu.hpp
@@ -1,12 +1,15 @@
 #pragma once
 #include "AMenu.hpp"
+#include "Slider.hpp"
+#include "ButtonsCluster.hpp"
+#include "Settings.hpp"
 
 struct SDL_Window;
 struct SDL_Renderer;
 
-// Menu for adjusting settings
 class SettingsMenu : public AMenu {
 public:
     SettingsMenu();
+    ButtonAction run(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
     static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
 };

--- a/inc/Slider.hpp
+++ b/inc/Slider.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <SDL.h>
+#include <vector>
+#include <string>
+
+class Slider {
+public:
+    std::string label;
+    std::vector<std::string> values;
+    int current = 0;
+    SDL_Rect bar{0,0,0,0};
+    bool dragging = false;
+
+    Slider() = default;
+    Slider(const std::string &l, const std::vector<std::string> &vals)
+        : label(l), values(vals) {}
+
+    void set_bar(int x, int y, int w, int h);
+    void handle_event(const SDL_Event &e);
+    void draw(SDL_Renderer *renderer, int scale) const;
+    std::string current_value() const { return values.empty() ? std::string() : values[current]; }
+};

--- a/src/ButtonsCluster.cpp
+++ b/src/ButtonsCluster.cpp
@@ -1,0 +1,50 @@
+#include "ButtonsCluster.hpp"
+#include "CustomCharacter.hpp"
+
+void ButtonsCluster::add(const std::string &text) {
+    items.push_back(Item{text, SDL_Rect{0,0,0,0}});
+}
+
+void ButtonsCluster::set_layout(int x, int y, int total_w, int h, int gap) {
+    if (items.empty()) return;
+    int w = (total_w - (static_cast<int>(items.size()) - 1) * gap) /
+            static_cast<int>(items.size());
+    for (std::size_t i = 0; i < items.size(); ++i) {
+        items[i].rect = {x + static_cast<int>(i) * (w + gap), y, w, h};
+    }
+}
+
+void ButtonsCluster::handle_event(const SDL_Event &e) {
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        int mx = e.button.x;
+        int my = e.button.y;
+        for (std::size_t i = 0; i < items.size(); ++i) {
+            SDL_Rect r = items[i].rect;
+            if (mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h) {
+                selected = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+}
+
+void ButtonsCluster::draw(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255,255,255,255};
+    for (std::size_t i = 0; i < items.size(); ++i) {
+        bool press = static_cast<int>(i) == selected;
+        SDL_Color fill = press ? SDL_Color{255,255,255,255} : SDL_Color{0,0,0,255};
+        SDL_Color text_color = press ? SDL_Color{0,0,0,255} : SDL_Color{255,255,255,255};
+        SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+        SDL_RenderFillRect(renderer, &items[i].rect);
+        SDL_SetRenderDrawColor(renderer, 255,255,255,255);
+        SDL_RenderDrawRect(renderer, &items[i].rect);
+        int tx = items[i].rect.x + (items[i].rect.w - CustomCharacter::text_width(items[i].text, scale))/2;
+        int ty = items[i].rect.y + (items[i].rect.h - 7*scale)/2;
+        CustomCharacter::draw_text(renderer, items[i].text, tx, ty, text_color, scale);
+    }
+}
+
+std::string ButtonsCluster::current_text() const {
+    if (items.empty()) return std::string();
+    return items[selected].text;
+}

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,6 +1,7 @@
 #include "Renderer.hpp"
 #include "AABB.hpp"
 #include "Config.hpp"
+#include "Settings.hpp"
 #include "Parser.hpp"
 #include "PauseMenu.hpp"
 #include <SDL.h>
@@ -308,7 +309,7 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                 {
                         if (st.edit_mode && st.rotating)
                         {
-                                double sens = MOUSE_SENSITIVITY;
+                                double sens = MOUSE_SENSITIVITY * g_settings.mouse_sensitivity;
                                 bool changed = false;
                                 double yaw = -e.motion.xrel * sens;
                                 if (yaw != 0.0)
@@ -339,7 +340,7 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                         }
                         else
                         {
-                                double sens = MOUSE_SENSITIVITY;
+                                double sens = MOUSE_SENSITIVITY * g_settings.mouse_sensitivity;
                                 cam.rotate(-e.motion.xrel * sens,
                                                    -e.motion.yrel * sens);
                         }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,0 +1,51 @@
+#include "Settings.hpp"
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+
+GameSettings g_settings; // defined global
+
+static std::string trim(const std::string &s) {
+    std::string::size_type start = s.find_first_not_of(" \t\n\r");
+    if (start == std::string::npos) return "";
+    std::string::size_type end = s.find_last_not_of(" \t\n\r");
+    return s.substr(start, end - start + 1);
+}
+
+bool load_settings(const std::string &path) {
+    g_settings = GameSettings(); // reset to defaults
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        return false;
+    }
+    std::string line;
+    while (std::getline(in, line)) {
+        auto pos = line.find(':');
+        if (pos == std::string::npos) continue;
+        std::string key = trim(line.substr(0, pos));
+        std::string value = trim(line.substr(pos + 1));
+        if (key == "quality" && !value.empty()) {
+            g_settings.quality = value[0];
+        } else if (key == "mouse_sensitivity") {
+            g_settings.mouse_sensitivity = std::stod(value);
+        } else if (key == "resolution") {
+            auto x = value.find('x');
+            if (x != std::string::npos) {
+                g_settings.width = std::stoi(value.substr(0, x));
+                g_settings.height = std::stoi(value.substr(x + 1));
+            }
+        }
+    }
+    return true;
+}
+
+bool save_settings(const std::string &path) {
+    std::ofstream out(path);
+    if (!out.is_open()) {
+        return false;
+    }
+    out << "quality: " << g_settings.quality << "\n";
+    out << "mouse_sensitivity: " << g_settings.mouse_sensitivity << "\n";
+    out << "resolution: " << g_settings.width << "x" << g_settings.height << "\n";
+    return true;
+}

--- a/src/SettingsMenu.cpp
+++ b/src/SettingsMenu.cpp
@@ -1,7 +1,139 @@
 #include "SettingsMenu.hpp"
+#include "CustomCharacter.hpp"
+#include <SDL.h>
+#include <sstream>
+#include <iomanip>
+#include <cmath>
 
 SettingsMenu::SettingsMenu() : AMenu("SETTINGS") {
-    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+    buttons.clear();
+    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255,0,0,255}});
+    buttons.push_back(Button{"APPLY", ButtonAction::None, SDL_Color{0,255,0,255}});
+}
+
+ButtonAction SettingsMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
+    ButtonsCluster quality;
+    quality.add("LOW");
+    quality.add("MEDIUM");
+    quality.add("HIGH");
+    if (g_settings.quality == 'L' || g_settings.quality == 'l') quality.selected = 0;
+    else if (g_settings.quality == 'M' || g_settings.quality == 'm') quality.selected = 1;
+    else quality.selected = 2;
+
+    std::vector<std::string> mouse_vals;
+    for (int i = 1; i <= 20; ++i) {
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(1) << 0.1 * i;
+        mouse_vals.push_back(ss.str());
+    }
+    Slider mouse_slider("MOUSE SENSITIVITY", mouse_vals);
+    int mouse_index = static_cast<int>(std::round((g_settings.mouse_sensitivity - 0.1) / 0.1));
+    if (mouse_index < 0) mouse_index = 0;
+    if (mouse_index >= (int)mouse_vals.size()) mouse_index = (int)mouse_vals.size() - 1;
+    mouse_slider.current = mouse_index;
+
+    std::vector<std::string> res_vals = {"720x480","1080x720","1366x768","1920x1080"};
+    Slider res_slider("RESOLUTION", res_vals);
+    int res_index = 1;
+    if (g_settings.width == 720 && g_settings.height == 480) res_index = 0;
+    else if (g_settings.width == 1080 && g_settings.height == 720) res_index = 1;
+    else if (g_settings.width == 1366 && g_settings.height == 768) res_index = 2;
+    else if (g_settings.width == 1920 && g_settings.height == 1080) res_index = 3;
+    res_slider.current = res_index;
+
+    bool running = true;
+    ButtonAction result = ButtonAction::None;
+    SDL_Color white{255,255,255,255};
+
+    while (running) {
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_QUIT) {
+                running = false;
+                result = ButtonAction::Quit;
+            }
+            mouse_slider.handle_event(e);
+            res_slider.handle_event(e);
+            quality.handle_event(e);
+            if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+                int mx = e.button.x;
+                int my = e.button.y;
+                for (auto &btn : buttons) {
+                    if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
+                        my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
+                        if (btn.text == "BACK") {
+                            running = false;
+                            result = ButtonAction::Back;
+                        } else if (btn.text == "APPLY") {
+                            g_settings.mouse_sensitivity = std::stod(mouse_slider.current_value());
+                            std::string q = quality.current_text();
+                            if (!q.empty()) g_settings.quality = q[0];
+                            std::string res = res_slider.current_value();
+                            auto x = res.find('x');
+                            if (x != std::string::npos) {
+                                g_settings.width = std::stoi(res.substr(0, x));
+                                g_settings.height = std::stoi(res.substr(x + 1));
+                                SDL_SetWindowSize(window, g_settings.width, g_settings.height);
+                            }
+                            save_settings();
+                            running = false;
+                            result = ButtonAction::Back;
+                        }
+                    }
+                }
+            }
+        }
+
+        SDL_GetWindowSize(window, &width, &height);
+        float scale_factor = static_cast<float>(height) / 600.0f;
+        int button_width = static_cast<int>(300 * scale_factor);
+        int button_height = static_cast<int>(80 * scale_factor);
+        int gap = static_cast<int>(20 * scale_factor);
+        int scale = static_cast<int>(4 * scale_factor);
+        if (scale < 1) scale = 1;
+        int title_scale = scale * 2;
+        int title_x = width / 2 - CustomCharacter::text_width(title, title_scale) / 2;
+        int title_y = gap;
+        int current_y = title_y + 7 * title_scale + gap * 2;
+        int center_x = width / 2 - button_width / 2;
+        int label_h = 7 * scale;
+
+        // layout for quality cluster
+        quality.set_layout(center_x, current_y + label_h + gap/2, button_width, button_height/2, gap/2);
+        int after_quality = current_y + label_h + gap/2 + button_height/2 + gap;
+        mouse_slider.set_bar(center_x, after_quality + label_h + gap/2, button_width, scale * 3);
+        int after_mouse = after_quality + label_h + gap/2 + scale * 3 + gap;
+        res_slider.set_bar(center_x, after_mouse + label_h + gap/2, button_width, scale * 3);
+        int bottom_y = height - button_height - gap;
+        int half_w = (button_width - gap) / 2;
+        buttons[0].rect = {center_x, bottom_y, half_w, button_height};
+        buttons[1].rect = {center_x + half_w + gap, bottom_y, half_w, button_height};
+
+        SDL_SetRenderDrawColor(renderer, 0,0,0,255);
+        SDL_RenderClear(renderer);
+        CustomCharacter::draw_text(renderer, title, title_x, title_y, white, title_scale);
+        CustomCharacter::draw_text(renderer, "QUALITY",
+                                   center_x + (button_width - CustomCharacter::text_width("QUALITY", scale))/2,
+                                   current_y, white, scale);
+        quality.draw(renderer, scale);
+        mouse_slider.draw(renderer, scale);
+        res_slider.draw(renderer, scale);
+
+        for (auto &btn : buttons) {
+            SDL_Color fill{0,0,0,255};
+            SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+            SDL_RenderFillRect(renderer, &btn.rect);
+            SDL_SetRenderDrawColor(renderer, 255,255,255,255);
+            SDL_RenderDrawRect(renderer, &btn.rect);
+            int tx = btn.rect.x + (btn.rect.w - CustomCharacter::text_width(btn.text, scale))/2;
+            int ty = btn.rect.y + (btn.rect.h - 7*scale)/2;
+            CustomCharacter::draw_text(renderer, btn.text, tx, ty, white, scale);
+        }
+
+        SDL_RenderPresent(renderer);
+        SDL_Delay(16);
+    }
+    return result;
 }
 
 void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {

--- a/src/Slider.cpp
+++ b/src/Slider.cpp
@@ -1,0 +1,57 @@
+#include "Slider.hpp"
+#include "CustomCharacter.hpp"
+#include <cmath>
+
+void Slider::set_bar(int x, int y, int w, int h) {
+    bar = {x, y, w, h};
+}
+
+void Slider::handle_event(const SDL_Event &e) {
+    if (values.empty()) return;
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        if (e.button.x >= bar.x && e.button.x <= bar.x + bar.w &&
+            e.button.y >= bar.y && e.button.y <= bar.y + bar.h) {
+            dragging = true;
+            int pos = e.button.x - bar.x;
+            int n = static_cast<int>(values.size()) - 1;
+            current = static_cast<int>(std::round(static_cast<double>(pos) / bar.w * n));
+            if (current < 0) current = 0;
+            if (current > n) current = n;
+        }
+    } else if (e.type == SDL_MOUSEBUTTONUP && e.button.button == SDL_BUTTON_LEFT) {
+        dragging = false;
+    } else if (e.type == SDL_MOUSEMOTION && dragging) {
+        int pos = e.motion.x - bar.x;
+        if (pos < 0) pos = 0;
+        if (pos > bar.w) pos = bar.w;
+        int n = static_cast<int>(values.size()) - 1;
+        current = static_cast<int>(std::round(static_cast<double>(pos) / bar.w * n));
+        if (current < 0) current = 0;
+        if (current > n) current = n;
+    }
+}
+
+void Slider::draw(SDL_Renderer *renderer, int scale) const {
+    if (values.empty()) return;
+    SDL_Color white{255,255,255,255};
+    int label_w = CustomCharacter::text_width(label, scale);
+    CustomCharacter::draw_text(renderer, label, bar.x + (bar.w - label_w)/2,
+                               bar.y - (7*scale + scale), white, scale);
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderDrawRect(renderer, &bar);
+    int n = static_cast<int>(values.size()) - 1;
+    for (int i = 0; i <= n; ++i) {
+        int x = bar.x + i * bar.w / n;
+        SDL_RenderDrawLine(renderer, x, bar.y, x, bar.y + bar.h);
+    }
+    int knob_x = bar.x + current * bar.w / n - scale;
+    SDL_Rect knob{knob_x, bar.y, scale*2, bar.h};
+    SDL_SetRenderDrawColor(renderer, 255,0,0,255);
+    SDL_RenderFillRect(renderer, &knob);
+    SDL_SetRenderDrawColor(renderer, 255,255,255,255);
+    std::string val = current_value();
+    CustomCharacter::draw_text(renderer, val,
+                               bar.x + bar.w + scale*2,
+                               bar.y + (bar.h - 7*scale)/2,
+                               white, scale);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "Application.hpp"
 #include "CommandLine.hpp"
 #include "MainMenu.hpp"
+#include "Settings.hpp"
 #include <string>
 
 /**
@@ -9,18 +10,22 @@
  */
 int main(int argc, char **argv)
 {
-	std::string scene_path;
-	int width;
-	int height;
-	char quality;
-	bool parsed;
-	parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
+        std::string scene_path;
+        load_settings();
+        int width = g_settings.width;
+        int height = g_settings.height;
+        char quality = g_settings.quality;
+        bool parsed;
+        parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
 	if (!parsed)
 	{
 		return 1;
 	}
-	bool play;
-	play = MainMenu::show(width, height);
+        g_settings.width = width;
+        g_settings.height = height;
+        g_settings.quality = quality;
+        bool play;
+        play = MainMenu::show(width, height);
 	if (!play)
 	{
 		return 0;


### PR DESCRIPTION
## Summary
- Implement settings system with YAML load/save and global settings
- Add slider and mutually exclusive button cluster UI components
- Build settings menu with quality, mouse sensitivity, resolution and apply/back
- Use settings in main and renderer for mouse sensitivity multiplier

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SDL2"; SDL2Config.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c18117b3c4832fbded4d328e790146