### PR TITLE
Add interactive settings menu with sliders and quality controls

### DIFF
--- a/inc/ButtonsCluster.hpp
+++ b/inc/ButtonsCluster.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <SDL.h>
+#include <string>
+#include <vector>
+
+class ButtonsCluster {
+private:
+    std::vector<std::string> texts;
+    std::vector<SDL_Rect> rects;
+    int selected;
+
+public:
+    ButtonsCluster(const std::vector<std::string> &labels, int default_index = 0);
+    void set_position(int x, int y, int button_width, int button_height, int gap);
+    bool handle_event(const SDL_Event &e);
+    void draw(SDL_Renderer *renderer, int scale) const;
+    int get_selected() const { return selected; }
+};

--- a/inc/Settings.hpp
+++ b/inc/Settings.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <string>
+
+struct Settings {
+    char quality;           // 'L', 'M', or 'H'
+    double mouse_sensitivity; // multiplier applied to MOUSE_SENSITIVITY
+    int width;
+    int height;
+
+    Settings();
+    static Settings load(const std::string &path = "settings.yaml");
+    void save(const std::string &path = "settings.yaml") const;
+};
+
+extern Settings g_settings;

--- a/inc/SettingsMenu.hpp
+++ b/inc/SettingsMenu.hpp
@@ -1,5 +1,8 @@
 #pragma once
 #include "AMenu.hpp"
+#include "ButtonsCluster.hpp"
+#include "Settings.hpp"
+#include "Slider.hpp"
 
 struct SDL_Window;
 struct SDL_Renderer;
@@ -8,5 +11,8 @@ struct SDL_Renderer;
 class SettingsMenu : public AMenu {
 public:
     SettingsMenu();
-    static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
+    ButtonAction run(SDL_Window *window, SDL_Renderer *renderer, int width,
+                     int height);
+    static void show(SDL_Window *window, SDL_Renderer *renderer, int width,
+                     int height);
 };

--- a/inc/Slider.hpp
+++ b/inc/Slider.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <SDL.h>
+#include <string>
+#include <vector>
+
+class Slider {
+private:
+    std::string label;
+    std::vector<std::string> values;
+    int index;
+    SDL_Rect track;
+    int knob_w;
+    int knob_h;
+    bool dragging;
+
+public:
+    Slider(const std::string &label, const std::vector<std::string> &vals,
+           int default_index = 0);
+    void set_position(int x, int y, int width, int scale);
+    bool handle_event(const SDL_Event &e);
+    void draw(SDL_Renderer *renderer, int scale) const;
+    int get_index() const { return index; }
+    const std::string &get_value() const { return values[index]; }
+};

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -49,11 +49,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                 for (auto &btn : buttons) {
                     if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
-                        if (btn.action != ButtonAction::Settings &&
-                            btn.action != ButtonAction::Leaderboard) {
-                            result = btn.action;
-                            running = false;
-                        }
+                        result = btn.action;
+                        running = false;
                         break;
                     }
                 }

--- a/src/ButtonsCluster.cpp
+++ b/src/ButtonsCluster.cpp
@@ -1,0 +1,59 @@
+#include "ButtonsCluster.hpp"
+#include "CustomCharacter.hpp"
+
+ButtonsCluster::ButtonsCluster(const std::vector<std::string> &labels,
+                               int default_index)
+    : texts(labels), rects(labels.size()), selected(default_index) {}
+
+void ButtonsCluster::set_position(int x, int y, int button_width, int button_height,
+                                  int gap) {
+    for (std::size_t i = 0; i < rects.size(); ++i) {
+        rects[i] = {x + static_cast<int>(i) * (button_width + gap), y, button_width,
+                    button_height};
+    }
+}
+
+bool ButtonsCluster::handle_event(const SDL_Event &e) {
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        int mx = e.button.x;
+        int my = e.button.y;
+        for (std::size_t i = 0; i < rects.size(); ++i) {
+            const SDL_Rect &r = rects[i];
+            if (mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h) {
+                selected = static_cast<int>(i);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void ButtonsCluster::draw(SDL_Renderer *renderer, int scale) const {
+    int mx, my;
+    SDL_GetMouseState(&mx, &my);
+    for (std::size_t i = 0; i < rects.size(); ++i) {
+        const SDL_Rect &r = rects[i];
+        bool hover = mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h;
+        if (static_cast<int>(i) == selected) {
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderFillRect(renderer, &r);
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderDrawRect(renderer, &r);
+            int tx = r.x + (r.w - CustomCharacter::text_width(texts[i], scale)) / 2;
+            int ty = r.y + (r.h - 7 * scale) / 2;
+            CustomCharacter::draw_text(renderer, texts[i], tx, ty,
+                                       SDL_Color{0, 0, 0, 255}, scale);
+        } else {
+            SDL_Color fill = hover ? SDL_Color{128, 128, 128, 255}
+                                   : SDL_Color{0, 0, 0, 255};
+            SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+            SDL_RenderFillRect(renderer, &r);
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderDrawRect(renderer, &r);
+            int tx = r.x + (r.w - CustomCharacter::text_width(texts[i], scale)) / 2;
+            int ty = r.y + (r.h - 7 * scale) / 2;
+            CustomCharacter::draw_text(renderer, texts[i], tx, ty,
+                                       SDL_Color{255, 255, 255, 255}, scale);
+        }
+    }
+}

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -1,4 +1,7 @@
 #include "MainMenu.hpp"
+#include "LeaderboardMenu.hpp"
+#include "SettingsMenu.hpp"
+#include "Settings.hpp"
 #include <SDL.h>
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
@@ -25,9 +28,26 @@ bool MainMenu::show(int width, int height) {
         return false;
     }
     MainMenu menu;
-    ButtonAction action = menu.run(window, renderer, width, height);
+    bool running = true;
+    bool play = false;
+    while (running) {
+        ButtonAction action = menu.run(window, renderer, width, height);
+        if (action == ButtonAction::Play) {
+            play = true;
+            running = false;
+        } else if (action == ButtonAction::Quit || action == ButtonAction::Back) {
+            running = false;
+        } else if (action == ButtonAction::Settings) {
+            SettingsMenu::show(window, renderer, width, height);
+            width = g_settings.width;
+            height = g_settings.height;
+            SDL_SetWindowSize(window, width, height);
+        } else if (action == ButtonAction::Leaderboard) {
+            LeaderboardMenu::show(window, renderer, width, height);
+        }
+    }
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return action == ButtonAction::Play;
+    return play;
 }

--- a/src/PauseMenu.cpp
+++ b/src/PauseMenu.cpp
@@ -1,4 +1,7 @@
 #include "PauseMenu.hpp"
+#include "LeaderboardMenu.hpp"
+#include "SettingsMenu.hpp"
+#include "Settings.hpp"
 
 PauseMenu::PauseMenu() : AMenu("PAUSE") {
     title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
@@ -8,8 +11,24 @@ PauseMenu::PauseMenu() : AMenu("PAUSE") {
     buttons.push_back(Button{"QUIT", ButtonAction::Quit, SDL_Color{255, 0, 0, 255}});
 }
 
-bool PauseMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
+bool PauseMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width,
+                     int height) {
     PauseMenu menu;
-    ButtonAction action = menu.run(window, renderer, width, height);
-    return action == ButtonAction::Resume;
+    bool running = true;
+    while (running) {
+        ButtonAction action = menu.run(window, renderer, width, height);
+        if (action == ButtonAction::Resume) {
+            return true;
+        } else if (action == ButtonAction::Quit || action == ButtonAction::Back) {
+            return false;
+        } else if (action == ButtonAction::Settings) {
+            SettingsMenu::show(window, renderer, width, height);
+            width = g_settings.width;
+            height = g_settings.height;
+            SDL_SetWindowSize(window, width, height);
+        } else if (action == ButtonAction::Leaderboard) {
+            LeaderboardMenu::show(window, renderer, width, height);
+        }
+    }
+    return false;
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp"
 #include "Parser.hpp"
 #include "PauseMenu.hpp"
+#include "Settings.hpp"
 #include <SDL.h>
 #include <algorithm>
 #include <atomic>
@@ -308,7 +309,8 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                 {
                         if (st.edit_mode && st.rotating)
                         {
-                                double sens = MOUSE_SENSITIVITY;
+                                double sens = g_settings.mouse_sensitivity *
+                                               MOUSE_SENSITIVITY;
                                 bool changed = false;
                                 double yaw = -e.motion.xrel * sens;
                                 if (yaw != 0.0)
@@ -339,9 +341,10 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                         }
                         else
                         {
-                                double sens = MOUSE_SENSITIVITY;
+                                double sens = g_settings.mouse_sensitivity *
+                                               MOUSE_SENSITIVITY;
                                 cam.rotate(-e.motion.xrel * sens,
-                                                   -e.motion.yrel * sens);
+                                           -e.motion.yrel * sens);
                         }
                 }
                 else if (e.type == SDL_MOUSEWHEEL)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,0 +1,56 @@
+#include "Settings.hpp"
+#include <fstream>
+#include <sstream>
+
+Settings::Settings() : quality('H'), mouse_sensitivity(1.0), width(1080), height(720) {}
+
+Settings Settings::load(const std::string &path) {
+    Settings s;
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        return s;
+    }
+    std::string line;
+    while (std::getline(in, line)) {
+        std::istringstream iss(line);
+        std::string key;
+        if (std::getline(iss, key, ':')) {
+            std::string value;
+            if (std::getline(iss, value)) {
+                // trim spaces
+                size_t start = value.find_first_not_of(" \t");
+                if (start != std::string::npos)
+                    value = value.substr(start);
+                if (key == "quality") {
+                    if (!value.empty())
+                        s.quality = value[0];
+                } else if (key == "mouse_sensitivity") {
+                    double v = s.mouse_sensitivity;
+                    std::istringstream(value) >> v;
+                    s.mouse_sensitivity = v;
+                } else if (key == "resolution") {
+                    int w, h;
+                    char x;
+                    std::istringstream(value) >> w >> x >> h;
+                    if (w > 0 && h > 0) {
+                        s.width = w;
+                        s.height = h;
+                    }
+                }
+            }
+        }
+    }
+    return s;
+}
+
+void Settings::save(const std::string &path) const {
+    std::ofstream out(path);
+    if (!out.is_open()) {
+        return;
+    }
+    out << "quality: " << quality << "\n";
+    out << "mouse_sensitivity: " << mouse_sensitivity << "\n";
+    out << "resolution: " << width << 'x' << height << "\n";
+}
+
+Settings g_settings = Settings::load();

--- a/src/SettingsMenu.cpp
+++ b/src/SettingsMenu.cpp
@@ -1,10 +1,181 @@
 #include "SettingsMenu.hpp"
+#include "CustomCharacter.hpp"
+#include <sstream>
 
 SettingsMenu::SettingsMenu() : AMenu("SETTINGS") {
     buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+    buttons.push_back(Button{"APPLY", ButtonAction::None, SDL_Color{0, 255, 0, 255}});
 }
 
-void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
+ButtonAction SettingsMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width,
+                               int height) {
+    bool running = true;
+    ButtonAction result = ButtonAction::Back;
+
+    // Prepare slider values
+    std::vector<std::string> sens_vals;
+    for (int i = 1; i <= 20; ++i) {
+        std::ostringstream ss;
+        ss.setf(std::ios::fixed);
+        ss.precision(1);
+        ss << (i / 10.0);
+        sens_vals.push_back(ss.str());
+    }
+    int sens_index = static_cast<int>(g_settings.mouse_sensitivity / 0.1) - 1;
+    if (sens_index < 0)
+        sens_index = 0;
+    if (sens_index > 19)
+        sens_index = 19;
+    Slider sens_slider("MOUSE SENSITIVITY", sens_vals, sens_index);
+
+    std::vector<std::string> res_vals{"720x480", "1080x720", "1366x768", "1920x1080"};
+    int res_index = 1;
+    if (g_settings.width == 720 && g_settings.height == 480)
+        res_index = 0;
+    else if (g_settings.width == 1080 && g_settings.height == 720)
+        res_index = 1;
+    else if (g_settings.width == 1366 && g_settings.height == 768)
+        res_index = 2;
+    else if (g_settings.width == 1920 && g_settings.height == 1080)
+        res_index = 3;
+    Slider res_slider("RESOLUTION", res_vals, res_index);
+
+    ButtonsCluster quality({"LOW", "MEDIUM", "HIGH"},
+                           g_settings.quality == 'L'
+                               ? 0
+                               : (g_settings.quality == 'M' ? 1 : 2));
+
+    while (running) {
+        SDL_GetWindowSize(window, &width, &height);
+        float scale_factor = static_cast<float>(height) / 600.0f;
+        int button_width = static_cast<int>(200 * scale_factor);
+        int button_height = static_cast<int>(80 * scale_factor);
+        int button_gap = static_cast<int>(10 * scale_factor);
+        int scale = static_cast<int>(4 * scale_factor);
+        if (scale < 1)
+            scale = 1;
+        int title_scale = scale * 2;
+        int title_height = 7 * title_scale;
+        int title_gap = static_cast<int>(40 * scale_factor);
+
+        int top_margin = static_cast<int>(40 * scale_factor);
+        int title_x = width / 2 - CustomCharacter::text_width(title, title_scale) / 2;
+        int title_y = top_margin;
+
+        int current_y = title_y + title_height + title_gap;
+
+        int quality_label_x = width / 2 -
+                              CustomCharacter::text_width("QUALITY", scale) / 2;
+        int quality_label_y = current_y;
+        current_y += 7 * scale + button_gap;
+        int cluster_total_width = 3 * button_width + 2 * button_gap;
+        int cluster_x = width / 2 - cluster_total_width / 2;
+        quality.set_position(cluster_x, current_y, button_width, button_height,
+                             button_gap);
+        current_y += button_height + title_gap;
+
+        int slider_width = static_cast<int>(400 * scale_factor);
+        int slider_height = scale * 4;
+        sens_slider.set_position(width / 2 - slider_width / 2, current_y, slider_width,
+                                 scale);
+        current_y += slider_height + title_gap;
+
+        res_slider.set_position(width / 2 - slider_width / 2, current_y, slider_width,
+                                scale);
+        current_y += slider_height + title_gap;
+
+        int bottom_total_width = 2 * button_width + button_gap;
+        int bottom_y = height - button_height - button_gap;
+        buttons[0].rect = {width / 2 - bottom_total_width / 2, bottom_y, button_width,
+                           button_height};
+        buttons[1].rect = {buttons[0].rect.x + button_width + button_gap, bottom_y,
+                           button_width, button_height};
+
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            sens_slider.handle_event(event);
+            res_slider.handle_event(event);
+            quality.handle_event(event);
+
+            if (event.type == SDL_QUIT) {
+                running = false;
+                result = ButtonAction::Quit;
+            } else if (event.type == SDL_MOUSEBUTTONDOWN &&
+                       event.button.button == SDL_BUTTON_LEFT) {
+                int mx = event.button.x;
+                int my = event.button.y;
+                for (auto &btn : buttons) {
+                    if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
+                        my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
+                        if (btn.text == "BACK") {
+                            running = false;
+                            result = ButtonAction::Back;
+                        } else if (btn.text == "APPLY") {
+                            int q = quality.get_selected();
+                            g_settings.quality = (q == 0 ? 'L' : (q == 1 ? 'M' : 'H'));
+                            g_settings.mouse_sensitivity =
+                                (sens_slider.get_index() + 1) * 0.1;
+                            int r = res_slider.get_index();
+                            if (r == 0) {
+                                g_settings.width = 720;
+                                g_settings.height = 480;
+                            } else if (r == 1) {
+                                g_settings.width = 1080;
+                                g_settings.height = 720;
+                            } else if (r == 2) {
+                                g_settings.width = 1366;
+                                g_settings.height = 768;
+                            } else {
+                                g_settings.width = 1920;
+                                g_settings.height = 1080;
+                            }
+                            g_settings.save();
+                            running = false;
+                            result = ButtonAction::Back;
+                        }
+                    }
+                }
+            }
+        }
+
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+        SDL_Color white{255, 255, 255, 255};
+        CustomCharacter::draw_text(renderer, title, title_x, title_y, white,
+                                   title_scale);
+        CustomCharacter::draw_text(renderer, "QUALITY", quality_label_x,
+                                   quality_label_y, white, scale);
+        quality.draw(renderer, scale);
+        sens_slider.draw(renderer, scale);
+        res_slider.draw(renderer, scale);
+
+        int mx, my;
+        SDL_GetMouseState(&mx, &my);
+        for (auto &btn : buttons) {
+            bool hover = mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
+                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h;
+            SDL_Color fill = hover ? btn.hover_color : SDL_Color{0, 0, 0, 255};
+            SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+            SDL_RenderFillRect(renderer, &btn.rect);
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderDrawRect(renderer, &btn.rect);
+            int text_x =
+                btn.rect.x +
+                (btn.rect.w - CustomCharacter::text_width(btn.text, scale)) / 2;
+            int text_y = btn.rect.y + (btn.rect.h - 7 * scale) / 2;
+            CustomCharacter::draw_text(renderer, btn.text, text_x, text_y, white,
+                                       scale);
+        }
+
+        SDL_RenderPresent(renderer);
+        SDL_Delay(16);
+    }
+
+    return result;
+}
+
+void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width,
+                        int height) {
     SettingsMenu menu;
     menu.run(window, renderer, width, height);
 }

--- a/src/Slider.cpp
+++ b/src/Slider.cpp
@@ -1,0 +1,75 @@
+#include "Slider.hpp"
+#include "CustomCharacter.hpp"
+#include <cmath>
+
+Slider::Slider(const std::string &lbl, const std::vector<std::string> &vals,
+               int default_index)
+    : label(lbl), values(vals), index(default_index), track{0, 0, 0, 0},
+      knob_w(0), knob_h(0), dragging(false) {}
+
+void Slider::set_position(int x, int y, int width, int scale) {
+    track = {x, y, width, scale};
+    knob_w = scale * 2;
+    knob_h = scale * 4;
+}
+
+bool Slider::handle_event(const SDL_Event &e) {
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        int mx = e.button.x;
+        int my = e.button.y;
+        SDL_Rect kb = {track.x + (track.w - knob_w) * index / (int(values.size()) - 1),
+                       track.y + track.h / 2 - knob_h / 2, knob_w, knob_h};
+        SDL_Rect expanded = {track.x, track.y - knob_h / 2, track.w, knob_h};
+        if ((mx >= kb.x && mx < kb.x + kb.w && my >= kb.y && my < kb.y + kb.h) ||
+            (mx >= expanded.x && mx < expanded.x + expanded.w &&
+             my >= expanded.y && my < expanded.y + expanded.h)) {
+            dragging = true;
+            // fall through to motion update
+        } else {
+            return false;
+        }
+    }
+    if (e.type == SDL_MOUSEBUTTONUP && e.button.button == SDL_BUTTON_LEFT) {
+        dragging = false;
+    }
+    if (e.type == SDL_MOUSEMOTION) {
+        if (dragging) {
+            int mx = e.motion.x;
+            double pos = (mx - track.x) / static_cast<double>(track.w);
+            if (pos < 0.0)
+                pos = 0.0;
+            if (pos > 1.0)
+                pos = 1.0;
+            int count = static_cast<int>(values.size()) - 1;
+            index = static_cast<int>(std::round(pos * count));
+        }
+    }
+    return dragging;
+}
+
+void Slider::draw(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255, 255, 255, 255};
+    // label
+    CustomCharacter::draw_text(renderer, label, track.x,
+                               track.y - 10 * scale - 7 * scale, white, scale);
+    // track
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderDrawRect(renderer, &track);
+    // ticks
+    if (values.size() > 1) {
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            int tx = track.x + (track.w - 1) * i / (int(values.size()) - 1);
+            SDL_RenderDrawLine(renderer, tx, track.y, tx, track.y + track.h);
+        }
+    }
+    // knob
+    SDL_Rect kb = {track.x + (track.w - knob_w) * index / (int(values.size()) - 1),
+                   track.y + track.h / 2 - knob_h / 2, knob_w, knob_h};
+    SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
+    SDL_RenderFillRect(renderer, &kb);
+
+    // value
+    int val_x = track.x + track.w + 10 * scale;
+    int val_y = track.y + track.h / 2 - (7 * scale) / 2;
+    CustomCharacter::draw_text(renderer, values[index], val_x, val_y, white, scale);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "Application.hpp"
 #include "CommandLine.hpp"
 #include "MainMenu.hpp"
+#include "Settings.hpp"
 #include <string>
 
 /**
@@ -14,17 +15,28 @@ int main(int argc, char **argv)
 	int height;
 	char quality;
 	bool parsed;
-	parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
-	if (!parsed)
-	{
-		return 1;
-	}
-	bool play;
-	play = MainMenu::show(width, height);
-	if (!play)
-	{
-		return 0;
-	}
-	run_application(scene_path, width, height, quality);
-	return 0;
+        parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
+        if (!parsed)
+        {
+                return 1;
+        }
+        // Override with settings from configuration file
+        width = g_settings.width;
+        height = g_settings.height;
+        quality = g_settings.quality;
+
+        bool play;
+        play = MainMenu::show(width, height);
+        if (!play)
+        {
+                return 0;
+        }
+
+        // Apply possibly updated settings
+        width = g_settings.width;
+        height = g_settings.height;
+        quality = g_settings.quality;
+
+        run_application(scene_path, width, height, quality);
+        return 0;
 }


### PR DESCRIPTION
## Summary
- implement configurable settings menu with mouse sensitivity and resolution sliders
- add ButtonsCluster and slider UI components and persistent settings YAML storage
- integrate settings with main and pause menus and renderer

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68c18117b3c4832fbded4d328e790146