### PR TITLE
Prevent camera movement on blocked object collisions

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -39,7 +39,6 @@ class Scene
         private:
         bool is_movable(int index) const;
         void apply_translation(const HittablePtr &object, const Vec3 &delta);
-        void attempt_axis_move(int index, const Vec3 &axis_delta, Vec3 &moved);
         void prepare_beam_roots(std::vector<std::shared_ptr<Laser>> &roots,
                                                         std::unordered_map<int, int> &id_map);
         void process_beams(const std::vector<Material> &mats,

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -482,9 +482,10 @@ void Renderer::update_selection(RenderState &st,
 
                 Vec3 desired = cam.origin + cam.forward * st.edit_dist;
                 Vec3 delta = desired - st.edit_pos;
+                Vec3 applied(0, 0, 0);
                 if (delta.length_squared() > 0)
                 {
-                        Vec3 applied = scene.move_with_collision(st.selected_obj, delta);
+                        applied = scene.move_with_collision(st.selected_obj, delta);
                         st.edit_pos += applied;
                         if (applied.length_squared() > 0)
                         {
@@ -493,10 +494,14 @@ void Renderer::update_selection(RenderState &st,
                         }
                 }
 
-                Vec3 cam_target = st.edit_pos - cam.forward * st.edit_dist;
-                Vec3 cam_delta = cam_target - cam.origin;
-                if (cam_delta.length_squared() > 0)
-                        scene.move_camera(cam, cam_delta, mats);
+                if (applied.length_squared() > 0)
+                {
+                        Vec3 cam_target =
+                                st.edit_pos - cam.forward * st.edit_dist;
+                        Vec3 cam_delta = cam_target - cam.origin;
+                        if (cam_delta.length_squared() > 0)
+                                scene.move_camera(cam, cam_delta, mats);
+                }
                 st.edit_dist = (st.edit_pos - cam.origin).length();
         }
         else

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -200,33 +200,21 @@ void Scene::build_bvh()
 // Move object by delta while preventing collisions.
 Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
 {
-	if (!is_movable(index))
-	{
-		return Vec3(0, 0, 0);
-	}
+        if (!is_movable(index))
+        {
+                return Vec3(0, 0, 0);
+        }
 
-	HittablePtr object;
-	object = objects[index];
+        HittablePtr object;
+        object = objects[index];
 
-	apply_translation(object, delta);
-	if (!collides(index))
-	{
-		return delta;
-	}
-	apply_translation(object, delta * -1);
-
-	Vec3 moved;
-	moved = Vec3(0, 0, 0);
-
-	Vec3 axis_deltas[3];
-	axis_deltas[0] = Vec3(delta.x, 0, 0);
-	axis_deltas[1] = Vec3(0, delta.y, 0);
-	axis_deltas[2] = Vec3(0, 0, delta.z);
-	for (const Vec3 &axis_delta : axis_deltas)
-	{
-		attempt_axis_move(index, axis_delta, moved);
-	}
-	return moved;
+        apply_translation(object, delta);
+        if (!collides(index))
+        {
+                return delta;
+        }
+        apply_translation(object, delta * -1);
+        return Vec3(0, 0, 0);
 }
 
 // Determine whether object is movable.
@@ -258,29 +246,9 @@ void Scene::apply_translation(const HittablePtr &object, const Vec3 &delta)
 	}
 }
 
-// Try moving object along a single axis, updating moved vector on success.
-void Scene::attempt_axis_move(int index, const Vec3 &axis_delta, Vec3 &moved)
-{
-	if (axis_delta.length_squared() == 0)
-	{
-		return;
-	}
-	HittablePtr object;
-	object = objects[index];
-	apply_translation(object, axis_delta);
-	if (collides(index))
-	{
-		apply_translation(object, axis_delta * -1);
-	}
-	else
-	{
-		moved += axis_delta;
-	}
-}
-
 // Move camera with collision avoidance.
 Vec3 Scene::move_camera(Camera &cam, const Vec3 &delta,
-						const std::vector<Material> &mats) const
+                                                const std::vector<Material> &mats) const
 {
 	auto blocked = [&](const Vec3 &start, const Vec3 &d)
 	{


### PR DESCRIPTION
## Summary
- Stop objects from sliding when movement is blocked by collisions
- Skip camera adjustments when an attempted object move is blocked

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68c53d6e3664832fbf56ab91b05e342a