### PR TITLE
Prevent camera movement when editing collision-blocked objects

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -482,22 +482,26 @@ void Renderer::update_selection(RenderState &st,
 
                 Vec3 desired = cam.origin + cam.forward * st.edit_dist;
                 Vec3 delta = desired - st.edit_pos;
+                Vec3 applied(0, 0, 0);
                 if (delta.length_squared() > 0)
                 {
-                        Vec3 applied = scene.move_with_collision(st.selected_obj, delta);
-                        st.edit_pos += applied;
+                        applied = scene.move_with_collision(st.selected_obj, delta);
                         if (applied.length_squared() > 0)
                         {
+                                st.edit_pos += applied;
                                 scene.update_beams(mats);
                                 scene.build_bvh();
                         }
                 }
 
-                Vec3 cam_target = st.edit_pos - cam.forward * st.edit_dist;
-                Vec3 cam_delta = cam_target - cam.origin;
-                if (cam_delta.length_squared() > 0)
-                        scene.move_camera(cam, cam_delta, mats);
-                st.edit_dist = (st.edit_pos - cam.origin).length();
+                if (applied.length_squared() > 0)
+                {
+                        Vec3 cam_target = st.edit_pos - cam.forward * st.edit_dist;
+                        Vec3 cam_delta = cam_target - cam.origin;
+                        if (cam_delta.length_squared() > 0)
+                                scene.move_camera(cam, cam_delta, mats);
+                        st.edit_dist = (st.edit_pos - cam.origin).length();
+                }
         }
         else
         {


### PR DESCRIPTION
## Summary
- Move selected objects before adjusting the camera and skip camera updates if the object can't move

## Testing
- `cmake .. && cmake --build .` *(fails: Could not find a package configuration file provided by "SDL2")*

------
https://chatgpt.com/codex/tasks/task_e_68c53d6e3664832fbf56ab91b05e342a