### PR TITLE
Avoid camera movement when object is blocked by collision

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -482,6 +482,7 @@ void Renderer::update_selection(RenderState &st,
 
                 Vec3 desired = cam.origin + cam.forward * st.edit_dist;
                 Vec3 delta = desired - st.edit_pos;
+                bool blocked = false;
                 if (delta.length_squared() > 0)
                 {
                         Vec3 applied = scene.move_with_collision(st.selected_obj, delta);
@@ -491,11 +492,12 @@ void Renderer::update_selection(RenderState &st,
                                 scene.update_beams(mats);
                                 scene.build_bvh();
                         }
+                        blocked = (applied - delta).length_squared() > 1e-9;
                 }
 
                 Vec3 cam_target = st.edit_pos - cam.forward * st.edit_dist;
                 Vec3 cam_delta = cam_target - cam.origin;
-                if (cam_delta.length_squared() > 0)
+                if (!blocked && cam_delta.length_squared() > 0)
                         scene.move_camera(cam, cam_delta, mats);
                 st.edit_dist = (st.edit_pos - cam.origin).length();
         }


### PR DESCRIPTION
## Summary
- Skip camera repositioning when object movement is blocked by a collision.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c53d6e3664832fbf56ab91b05e342a