### PR TITLE
Adjust beam sphere radii and collision handling

### DIFF
--- a/inc/BeamSource.hpp
+++ b/inc/BeamSource.hpp
@@ -18,7 +18,8 @@ class BeamSource : public Sphere
 	{
 		return Sphere::bounding_box(out);
 	}
-	void translate(const Vec3 &delta) override;
-	void rotate(const Vec3 &axis, double angle) override;
-	Vec3 spot_direction() const override;
+        void translate(const Vec3 &delta) override;
+        void rotate(const Vec3 &axis, double angle) override;
+        Vec3 spot_direction() const override;
+        bool blocks_when_transparent() const override { return true; }
 };

--- a/inc/BeamTarget.hpp
+++ b/inc/BeamTarget.hpp
@@ -9,4 +9,5 @@ public:
     bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
     bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }
     void translate(const Vec3 &delta) override;
+    bool blocks_when_transparent() const override { return true; }
 };

--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -43,10 +43,11 @@ class Hittable
 					 HitRecord &rec) const = 0;
 	virtual bool bounding_box(AABB &out) const = 0;
 	virtual ShapeType shape_type() const { return ShapeType::Generic; }
-	virtual bool is_beam() const { return false; }
-	virtual bool is_plane() const { return false; }
-	virtual bool is_bvh() const { return false; }
-	// default translation does nothing
+        virtual bool is_beam() const { return false; }
+        virtual bool is_plane() const { return false; }
+        virtual bool is_bvh() const { return false; }
+        virtual bool blocks_when_transparent() const { return false; }
+        // default translation does nothing
 	virtual void translate(const Vec3 &delta) { (void)delta; }
 	// default rotation does nothing
 	virtual void rotate(const Vec3 &axis, double angle)

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -5,8 +5,8 @@ BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
                                            const std::shared_ptr<Laser> &bm, double mid_radius,
                                            int oid, int mat_big, int mat_mid, int mat_small)
        : Sphere(c, mid_radius * 2.0, oid, mat_big),
-         mid(c, mid_radius, -oid - 1, mat_mid),
-         inner(c, mid_radius * 0.5, -oid - 2, mat_small), beam(bm)
+         mid(c, mid_radius * 1.5, -oid - 1, mat_mid),
+         inner(c, mid_radius, -oid - 2, mat_small), beam(bm)
 {
         (void)dir;
 }

--- a/src/BeamTarget.cpp
+++ b/src/BeamTarget.cpp
@@ -2,8 +2,8 @@
 
 BeamTarget::BeamTarget(const Vec3 &c, double outer_radius, int oid, int mat_big, int mat_mid, int mat_small)
     : Sphere(c, outer_radius, oid, mat_big),
-      mid(c, outer_radius * 0.5, -oid - 1, mat_mid),
-      inner(c, outer_radius * 0.25, -oid - 2, mat_small) {}
+      mid(c, outer_radius * 0.75, -oid - 1, mat_mid),
+      inner(c, outer_radius * 0.5, -oid - 2, mat_small) {}
 
 bool BeamTarget::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const {
     bool hit_any = false;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -287,20 +287,20 @@ Vec3 Scene::move_camera(Camera &cam, const Vec3 &delta,
 		double len = d.length();
 		if (len <= 0.0)
 			return false;
-		Ray r(start, d / len);
-		HitRecord tmp;
-		for (const auto &obj : objects)
-		{
-			if (obj->is_beam())
-				continue;
-			const Material &mat = mats[obj->material_id];
-			if (mat.alpha < 1.0)
-				continue;
-			if (obj->hit(r, 1e-4, len, tmp))
-				return true;
-		}
-		return false;
-	};
+                Ray r(start, d / len);
+                HitRecord tmp;
+                for (const auto &obj : objects)
+                {
+                        if (obj->is_beam())
+                                continue;
+                        const Material &mat = mats[obj->material_id];
+                        if (mat.alpha < 1.0 && !obj->blocks_when_transparent())
+                                continue;
+                        if (obj->hit(r, 1e-4, len, tmp))
+                                return true;
+                }
+                return false;
+        };
 
 	Vec3 start = cam.origin;
 	if (!blocked(start, delta))


### PR DESCRIPTION
## Summary
- Adjust BeamSource and BeamTarget sphere ratios so mid sphere is 75% and inner sphere is 50% of outer radius
- Ensure transparent BeamSource/BeamTarget outer spheres still block camera movement by adding `blocks_when_transparent`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c5424d67b0832fb6fb933d4cb8d1f0