### PR TITLE
Ensure game focuses after starting and Escape resumes

### DIFF
--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -1,6 +1,7 @@
 #include "AMenu.hpp"
 #include "SettingsMenu.hpp"
 #include "LeaderboardMenu.hpp"
+#include <algorithm>
 
 AMenu::AMenu(const std::string &t) : title(t) {}
 
@@ -59,6 +60,17 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             if (event.type == SDL_QUIT) {
                 running = false;
                 result = ButtonAction::Quit;
+            } else if (event.type == SDL_KEYDOWN &&
+                       event.key.keysym.scancode == SDL_SCANCODE_ESCAPE) {
+                auto resume_btn = std::find_if(buttons.begin(), buttons.end(),
+                                               [](const Button &b) {
+                                                   return b.action ==
+                                                          ButtonAction::Resume;
+                                               });
+                if (resume_btn != buttons.end()) {
+                    result = ButtonAction::Resume;
+                    running = false;
+                }
             } else if (event.type == SDL_MOUSEBUTTONDOWN &&
                        event.button.button == SDL_BUTTON_LEFT) {
                 int mx = event.button.x;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -744,6 +744,12 @@ void Renderer::render_window(std::vector<Material> &mats,
                 return;
 
         RenderState st;
+        st.focused = true;
+        SDL_SetRelativeMouseMode(SDL_TRUE);
+        SDL_ShowCursor(SDL_DISABLE);
+        SDL_SetWindowGrab(win, SDL_TRUE);
+        SDL_WarpMouseInWindow(win, W / 2, H / 2);
+
         std::vector<Vec3> framebuffer(RW * RH);
         std::vector<unsigned char> pixels(RW * RH * 3);
         Uint32 last = SDL_GetTicks();


### PR DESCRIPTION
## Summary
- Grab mouse/keyboard focus when the renderer starts so the game is immediately controllable after Play/Resume
- Handle Escape key in menus to trigger Resume, allowing Escape to close the pause menu

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68c55ac662f8832fb262855d65184e3e