### PR TITLE
Center window on resize and simplify CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,28 +38,12 @@ Puzzle game based on miniRT 42School project.
 
 ### Windows
 ```bash
-./build/minirt.exe scenes/[map].rt [width height L|M|H]
+./build/minirt.exe scenes/[map].rt
 ```
 
 ### Linux
 ```bash
-./build/minirt scenes/[map].rt [width height L|M|H]
+./build/minirt scenes/[map].rt
 ```
 
-Optional `width`, `height`, and a final quality argument control the output image size and internal render scale. The renderer automatically uses all available hardware threads. Quality can be specified with `L`, `M`, or `H` (low, medium, high) and defaults to `H`.
-
-For example:
-
-```bash
-./build/minirt scenes/[map].rt 1080 720 L
-```
-
-You can omit the resolution while still supplying quality at the end, or specify resolution and quality together:
-
-```bash
-./build/minirt scenes/[map].rt L
-./build/minirt scenes/[map].rt 1080 720 L
-```
-
-`M` renders at two-thirds resolution (dividing width and height by 1.5) and `L` renders at half resolution (dividing by 2) while scaling the result to the requested window size.
 The `scenes` directory contains sample `.rt` files.

--- a/inc/CommandLine.hpp
+++ b/inc/CommandLine.hpp
@@ -8,10 +8,6 @@
  * @param argc Argument count.
  * @param argv Argument values.
  * @param scene_path Output path to scene file.
- * @param width Output width.
- * @param height Output height.
- * @param quality Output quality character.
  * @return True on success.
  */
-bool parse_arguments(int argc, char **argv, std::string &scene_path, int &width,
-					 int &height, char &quality);
+bool parse_arguments(int argc, char **argv, std::string &scene_path);

--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -1,43 +1,13 @@
 #include "CommandLine.hpp"
-#include <cstdlib>
 #include <iostream>
 
-bool parse_arguments(int argc, char **argv, std::string &scene_path, int &width,
-					 int &height, char &quality)
+bool parse_arguments(int argc, char **argv, std::string &scene_path)
 {
-	if (argc < 2)
-	{
-		std::cerr << "Usage: minirt <scene.rt> [width height L|M|H]\n";
-		return false;
-	}
-	scene_path = argv[1];
-	quality = 'H';
-	if (argc > 2)
-	{
-		std::string last;
-		last = argv[argc - 1];
-		if (last.size() == 1 && (last == "L" || last == "M" || last == "H" ||
-								 last == "l" || last == "m" || last == "h"))
-		{
-			quality = last[0];
-			--argc;
-		}
-	}
-	if (argc > 2)
-	{
-		width = std::atoi(argv[2]);
-	}
-	else
-	{
-		width = 800;
-	}
-	if (argc > 3)
-	{
-		height = std::atoi(argv[3]);
-	}
-	else
-	{
-		height = 600;
-	}
-	return true;
+        if (argc != 2)
+        {
+                std::cerr << "Usage: minirt <scene.rt>\n";
+                return false;
+        }
+        scene_path = argv[1];
+        return true;
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -190,8 +190,8 @@ bool Renderer::init_sdl(SDL_Window *&win, SDL_Renderer *&ren, SDL_Texture *&tex,
                 std::cerr << "SDL_Init Error: " << SDL_GetError() << "\n";
                 return false;
         }
-        win = SDL_CreateWindow("MiniRT", SDL_WINDOWPOS_UNDEFINED,
-                                                   SDL_WINDOWPOS_UNDEFINED, W, H, 0);
+        win = SDL_CreateWindow("MiniRT", SDL_WINDOWPOS_CENTERED,
+                                                   SDL_WINDOWPOS_CENTERED, W, H, 0);
         if (!win)
         {
                 std::cerr << "SDL_CreateWindow Error: " << SDL_GetError() << "\n";

--- a/src/SettingsMenu.cpp
+++ b/src/SettingsMenu.cpp
@@ -456,6 +456,8 @@ ButtonAction SettingsMenu::run(SDL_Window *window, SDL_Renderer *renderer, int w
                                     std::atoi(cur.substr(x + 1).c_str());
                                 SDL_SetWindowSize(window, g_settings.width,
                                                   g_settings.height);
+                                SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED,
+                                                      SDL_WINDOWPOS_CENTERED);
                             }
                             save_settings();
                             running = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,21 +10,14 @@
 int main(int argc, char **argv)
 {
         std::string scene_path;
-        int width;
-        int height;
-        char quality;
-        bool parsed;
-        parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
-        if (!parsed)
+        if (!parse_arguments(argc, argv, scene_path))
         {
                 return 1;
         }
         load_settings();
-        width = g_settings.width;
-        height = g_settings.height;
-        quality = g_settings.quality;
-        bool play;
-        play = MainMenu::show(width, height);
+        int width = g_settings.width;
+        int height = g_settings.height;
+        bool play = MainMenu::show(width, height);
         if (!play)
         {
                 return 0;


### PR DESCRIPTION
## Summary
- center resized and newly created windows on the screen
- simplify command line interface to accept only a scene file
- update running instructions in README

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c56354ba10832fbd0884e311b75d7b