### PR TITLE
Reflect light sources in reflections

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -144,13 +144,13 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
 	}
 	if (m.mirror)
 	{
-		Vec3 refl_dir =
-			r.dir - rec.normal * (2.0 * Vec3::dot(r.dir, rec.normal));
-		Ray refl(rec.p + refl_dir * 1e-4, refl_dir);
-		Vec3 refl_col = trace_ray(scene, mats, refl, rng, dist, depth + 1);
-		double refl_ratio = REFLECTION / 100.0;
-		sum = sum * (1.0 - refl_ratio) + refl_col * refl_ratio;
-	}
+                Vec3 refl_dir =
+                        r.dir - rec.normal * (2.0 * Vec3::dot(r.dir, rec.normal));
+                Ray refl(rec.p + refl_dir * 1e-4, refl_dir);
+                Vec3 refl_col = trace_ray(scene, mats, refl, rng, dist, depth + 1);
+                double refl_ratio = REFLECTION / 100.0;
+                sum = sum * (1.0 - refl_ratio) + refl_col;
+        }
 	double alpha = m.alpha;
 	if (m.random_alpha)
 	{


### PR DESCRIPTION
## Summary
- show point lights and beam spotlights in mirror reflections

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c578d9b220832f905953aec69a8718