### PR TITLE
Reflect scene lights from mirrors

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -49,4 +49,5 @@ class Scene
                                                std::vector<std::shared_ptr<Laser>> &roots,
                                                std::unordered_map<int, int> &id_map);
         void remap_light_ids(const std::unordered_map<int, int> &id_map);
+        void reflect_lights(const std::vector<Material> &mats);
 };

--- a/inc/light.hpp
+++ b/inc/light.hpp
@@ -8,17 +8,18 @@ class PointLight
 	public:
 	Vec3 position;
 	Vec3 color;
-	double intensity;
-	std::vector<int> ignore_ids;
-	int attached_id;
-	Vec3 direction;
-	double cutoff_cos;
-	double range;
+        double intensity;
+        std::vector<int> ignore_ids;
+        int attached_id;
+        Vec3 direction;
+        double cutoff_cos;
+        double range;
+        bool reflected;
 
-	PointLight(const Vec3 &p, const Vec3 &c, double i,
-			   std::vector<int> ignore_ids = {}, int attached_id = -1,
-			   const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0,
-			   double range = -1.0);
+        PointLight(const Vec3 &p, const Vec3 &c, double i,
+                           std::vector<int> ignore_ids = {}, int attached_id = -1,
+                           const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0,
+                           double range = -1.0, bool reflected = false);
 };
 
 class Ambient

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -26,8 +26,8 @@ void Scene::prepare_beam_roots(std::vector<std::shared_ptr<Laser>> &roots,
         static_lights.reserve(lights.size());
         for (const auto &L : lights)
         {
-                bool keep = true;
-                if (L.attached_id >= 0)
+                bool keep = !L.reflected;
+                if (keep && L.attached_id >= 0)
                 {
                         auto it = std::find_if(objects.begin(), objects.end(),
                                                                    [&](const HittablePtr &o)
@@ -242,7 +242,7 @@ void Scene::reflect_lights(const std::vector<Material> &mats)
                 std::vector<int> ignore = L.ignore_ids;
                 ignore.push_back(hit_rec.object_id);
                 PointLight new_light(refl_orig, L.color, intensity, ignore, -1,
-                                                         refl_dir, L.cutoff_cos, remain);
+                                                         refl_dir, L.cutoff_cos, remain, true);
                 to_process.push_back({new_light, new_start, seg.total, seg.depth + 1});
         }
 }

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -2,10 +2,12 @@
 #include <utility>
 
 PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
-					   std::vector<int> ignore_ids, int attached_id,
-					   const Vec3 &dir, double cutoff, double range)
-	: position(p), color(c), intensity(i), ignore_ids(std::move(ignore_ids)),
-	  attached_id(attached_id), direction(dir), cutoff_cos(cutoff), range(range)
+                                           std::vector<int> ignore_ids, int attached_id,
+                                           const Vec3 &dir, double cutoff, double range,
+                                           bool reflected)
+        : position(p), color(c), intensity(i), ignore_ids(std::move(ignore_ids)),
+          attached_id(attached_id), direction(dir), cutoff_cos(cutoff), range(range),
+          reflected(reflected)
 {
 }
 


### PR DESCRIPTION
## Summary
- Reflect directional lights and beam spotlights off mirror materials
- Track light reflections during beam updates

## Testing
- `cmake ..` *(fails: Could not find SDL2Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c578d9b220832f905953aec69a8718