### PR TITLE
Refresh reflected lights after object movement

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -33,8 +33,9 @@ class Scene
 	// Determine whether object at index collides with others.
 	bool collides(int index) const;
 
-	// Move object while preventing collisions.
-	Vec3 move_with_collision(int index, const Vec3 &delta);
+        // Move object while preventing collisions.
+        Vec3 move_with_collision(int index, const Vec3 &delta,
+                                                        const std::vector<Material> &materials);
 
 	// Move camera while avoiding obstacles.
         Vec3 move_camera(Camera &cam, const Vec3 &delta,

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -270,11 +270,10 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                                         if (delta.length_squared() > 0)
                                         {
                                                 Vec3 applied = scene.move_with_collision(
-                                                        st.selected_obj, delta);
+                                                        st.selected_obj, delta, mats);
                                                 center += applied;
                                                 if (applied.length_squared() > 0)
                                                 {
-                                                        scene.update_beams(mats);
                                                         scene.build_bvh();
                                                         st.edit_dist =
                                                                 (center - cam.origin).length();
@@ -484,11 +483,10 @@ void Renderer::update_selection(RenderState &st,
                 Vec3 delta = desired - st.edit_pos;
                 if (delta.length_squared() > 0)
                 {
-                        Vec3 applied = scene.move_with_collision(st.selected_obj, delta);
+                        Vec3 applied = scene.move_with_collision(st.selected_obj, delta, mats);
                         st.edit_pos += applied;
                         if (applied.length_squared() > 0)
                         {
-                                scene.update_beams(mats);
                                 scene.build_bvh();
                         }
                 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -282,7 +282,8 @@ void Scene::build_bvh()
 }
 
 // Move object by delta while preventing collisions.
-Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
+Vec3 Scene::move_with_collision(int index, const Vec3 &delta,
+                                                       const std::vector<Material> &mats)
 {
 	if (!is_movable(index))
 	{
@@ -306,11 +307,13 @@ Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
 	axis_deltas[0] = Vec3(delta.x, 0, 0);
 	axis_deltas[1] = Vec3(0, delta.y, 0);
 	axis_deltas[2] = Vec3(0, 0, delta.z);
-	for (const Vec3 &axis_delta : axis_deltas)
-	{
-		attempt_axis_move(index, axis_delta, moved);
-	}
-	return moved;
+        for (const Vec3 &axis_delta : axis_deltas)
+        {
+                attempt_axis_move(index, axis_delta, moved);
+        }
+        if (moved.length_squared() > 0.0)
+                update_beams(mats);
+        return moved;
 }
 
 // Determine whether object is movable.


### PR DESCRIPTION
## Summary
- Recompute beam and light reflections automatically when objects move by passing materials into `move_with_collision` and updating beams internally.
- Adjust renderer to rely on this behavior and rebuild the BVH without redundant beam updates.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c57d987c60832fa13317c9d0ffbf02