### PR TITLE
Update reflected lights with object movement

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -34,7 +34,8 @@ class Scene
 	bool collides(int index) const;
 
 	// Move object while preventing collisions.
-	Vec3 move_with_collision(int index, const Vec3 &delta);
+        Vec3 move_with_collision(int index, const Vec3 &delta,
+                                                 const std::vector<Material> &materials);
 
 	// Move camera while avoiding obstacles.
         Vec3 move_camera(Camera &cam, const Vec3 &delta,

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -270,11 +270,10 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                                         if (delta.length_squared() > 0)
                                         {
                                                 Vec3 applied = scene.move_with_collision(
-                                                        st.selected_obj, delta);
+                                                        st.selected_obj, delta, mats);
                                                 center += applied;
                                                 if (applied.length_squared() > 0)
                                                 {
-                                                        scene.update_beams(mats);
                                                         scene.build_bvh();
                                                         st.edit_dist =
                                                                 (center - cam.origin).length();
@@ -484,11 +483,10 @@ void Renderer::update_selection(RenderState &st,
                 Vec3 delta = desired - st.edit_pos;
                 if (delta.length_squared() > 0)
                 {
-                        Vec3 applied = scene.move_with_collision(st.selected_obj, delta);
+                        Vec3 applied = scene.move_with_collision(st.selected_obj, delta, mats);
                         st.edit_pos += applied;
                         if (applied.length_squared() > 0)
                         {
-                                scene.update_beams(mats);
                                 scene.build_bvh();
                         }
                 }


### PR DESCRIPTION
## Summary
- Recalculate reflected lights whenever an object is moved by invoking beam/light updates inside `Scene::move_with_collision`
- Adjust renderer object movement paths to use the new API and remove redundant light updates

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c57d987c60832fa13317c9d0ffbf02