### PR TITLE
Automatically refresh reflected lights on object movement

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -25,7 +25,7 @@ class Scene
         void update_goal_targets(double dt, std::vector<Material> &materials);
 
 	// Build bounding volume hierarchy for static geometry.
-	void build_bvh();
+        void build_bvh();
 
 	// Test a ray against all objects.
 	bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
@@ -50,4 +50,7 @@ class Scene
                                                std::unordered_map<int, int> &id_map);
         void remap_light_ids(const std::unordered_map<int, int> &id_map);
         void reflect_lights(const std::vector<Material> &mats);
+
+        // Cached pointer to materials for automatic light updates on moves.
+        const std::vector<Material> *materials_ref = nullptr;
 };

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -274,7 +274,6 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                                                 center += applied;
                                                 if (applied.length_squared() > 0)
                                                 {
-                                                        scene.update_beams(mats);
                                                         scene.build_bvh();
                                                         st.edit_dist =
                                                                 (center - cam.origin).length();
@@ -488,7 +487,6 @@ void Renderer::update_selection(RenderState &st,
                         st.edit_pos += applied;
                         if (applied.length_squared() > 0)
                         {
-                                scene.update_beams(mats);
                                 scene.build_bvh();
                         }
                 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -250,6 +250,7 @@ void Scene::reflect_lights(const std::vector<Material> &mats)
 // Remove finished beam segments and spawn new beams for reflections.
 void Scene::update_beams(const std::vector<Material> &mats)
 {
+        materials_ref = &mats;
         std::vector<std::shared_ptr<Laser>> roots;
         std::unordered_map<int, int> id_map;
         prepare_beam_roots(roots, id_map);
@@ -306,11 +307,13 @@ Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
 	axis_deltas[0] = Vec3(delta.x, 0, 0);
 	axis_deltas[1] = Vec3(0, delta.y, 0);
 	axis_deltas[2] = Vec3(0, 0, delta.z);
-	for (const Vec3 &axis_delta : axis_deltas)
-	{
-		attempt_axis_move(index, axis_delta, moved);
-	}
-	return moved;
+        for (const Vec3 &axis_delta : axis_deltas)
+        {
+                attempt_axis_move(index, axis_delta, moved);
+        }
+        if (moved.length_squared() > 0 && materials_ref)
+                update_beams(*materials_ref);
+        return moved;
 }
 
 // Determine whether object is movable.


### PR DESCRIPTION
## Summary
- Cache material list within `Scene` for reuse
- Recompute beams and reflected lights whenever an object moves
- Remove redundant light-updating calls from renderer

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c57d987c60832fa13317c9d0ffbf02