### PR TITLE
Add laser toggle argument to beam parser

### DIFF
--- a/inc/Beam.hpp
+++ b/inc/Beam.hpp
@@ -12,5 +12,6 @@ class Beam
        std::shared_ptr<BeamSource> source;
        Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                 double length, double intensity, int base_oid, int laser_mat,
-                int big_mat, int mid_mat, int small_mat);
+                int big_mat, int mid_mat, int small_mat,
+                bool enable_laser = true);
 };

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -2,13 +2,19 @@
 
 Beam::Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                   double length, double intensity, int base_oid, int laser_mat,
-                  int big_mat, int mid_mat, int small_mat)
+                  int big_mat, int mid_mat, int small_mat, bool enable_laser)
 {
        light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity);
-       laser = std::make_shared<Laser>(origin, dir, length, intensity, base_oid,
-                                                                       laser_mat);
+       int source_oid = base_oid;
+       if (enable_laser)
+       {
+               laser = std::make_shared<Laser>(
+                       origin, dir, length, intensity, base_oid, laser_mat);
+               source_oid = base_oid + 1;
+       }
        source = std::make_shared<BeamSource>(
-               origin, dir, laser, ray_radius, base_oid + 1, big_mat, mid_mat,
+               origin, dir, laser, ray_radius, source_oid, big_mat, mid_mat,
                small_mat);
-       laser->source = source;
+       if (laser)
+               laser->source = source;
 }

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -270,9 +270,18 @@ static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid
 {
        std::string s_intens, s_pos, s_dir, s_rgb, s_r, s_L;
        iss >> s_intens >> s_pos >> s_dir >> s_rgb >> s_r >> s_L;
-        std::string s_move;
-        if (!(iss >> s_move))
-                s_move = "IM";
+        std::string s_move = "IM";
+        std::string s_laser = "L";
+        if (iss >> s_move)
+        {
+                if (s_move == "L" || s_move == "NL")
+                {
+                        s_laser = s_move;
+                        s_move = "IM";
+                }
+                else if (!(iss >> s_laser))
+                        s_laser = "L";
+        }
        Vec3 o, dir, rgb;
        double ray_radius = 0.1, L = 1.0, intensity = 0.75;
         double a = 255;
@@ -308,20 +317,35 @@ static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid
                 mats.back().alpha = 1.0;
                 int small_mat = mid++;
 
+               bool laser_on = (s_laser != "NL");
                auto bm = std::make_shared<Beam>(o, dir_norm, ray_radius, L,
                                                                                         intensity, oid, beam_mat,
-                                                                                        big_mat, mid_mat, small_mat);
-                oid += 2;
+                                                                                        big_mat, mid_mat, small_mat,
+                                                                                        laser_on);
                 bm->source->movable = (s_move == "M");
-                scene.objects.push_back(bm->laser);
-                scene.objects.push_back(bm->source);
                 const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
-                scene.lights.emplace_back(
-                        o, unit, intensity,
-                        std::vector<int>{bm->laser->object_id,
-                                                         bm->source->object_id,
-                                                         bm->source->mid.object_id},
-                        bm->source->object_id, dir_norm, cone_cos, L);
+                if (laser_on)
+                {
+                        scene.objects.push_back(bm->laser);
+                        scene.objects.push_back(bm->source);
+                        scene.lights.emplace_back(
+                                o, unit, intensity,
+                                std::vector<int>{bm->laser->object_id,
+                                                                 bm->source->object_id,
+                                                                 bm->source->mid.object_id},
+                                bm->source->object_id, dir_norm, cone_cos, L);
+                        oid += 2;
+                }
+                else
+                {
+                        scene.objects.push_back(bm->source);
+                        scene.lights.emplace_back(
+                                o, unit, intensity,
+                                std::vector<int>{bm->source->object_id,
+                                                                 bm->source->mid.object_id},
+                                bm->source->object_id, dir_norm, cone_cos, L);
+                        ++oid;
+                }
         }
 }
 


### PR DESCRIPTION
## Summary
- allow beam definitions to specify optional `L`/`NL` flag
- create beams without laser when `NL` is used
- conditionally add beam objects and lights based on laser flag

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c6eb5a3e10832fa37d73451e0a8486