### PR TITLE
Add rotation toggle to beam parser

### DIFF
--- a/inc/Beam.hpp
+++ b/inc/Beam.hpp
@@ -12,5 +12,6 @@ class Beam
        std::shared_ptr<BeamSource> source;
        Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                 double length, double intensity, int base_oid, int laser_mat,
-                int big_mat, int mid_mat, int small_mat);
+                int big_mat, int mid_mat, int small_mat,
+                bool enable_laser = true);
 };

--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -35,10 +35,11 @@ class HitRecord
 
 class Hittable
 {
-	public:
-	bool movable = false;
-	int object_id = 0;
-	int material_id = 0;
+        public:
+       bool movable = false;
+       bool rotatable = true;
+       int object_id = 0;
+       int material_id = 0;
 	virtual ~Hittable() = default;
 	virtual bool hit(const Ray &r, double tmin, double tmax,
 					 HitRecord &rec) const = 0;

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -2,13 +2,19 @@
 
 Beam::Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                   double length, double intensity, int base_oid, int laser_mat,
-                  int big_mat, int mid_mat, int small_mat)
+                  int big_mat, int mid_mat, int small_mat, bool enable_laser)
 {
        light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity);
-       laser = std::make_shared<Laser>(origin, dir, length, intensity, base_oid,
-                                                                       laser_mat);
+       int source_oid = base_oid;
+       if (enable_laser)
+       {
+               laser = std::make_shared<Laser>(
+                       origin, dir, length, intensity, base_oid, laser_mat);
+               source_oid = base_oid + 1;
+       }
        source = std::make_shared<BeamSource>(
-               origin, dir, laser, ray_radius, base_oid + 1, big_mat, mid_mat,
+               origin, dir, laser, ray_radius, source_oid, big_mat, mid_mat,
                small_mat);
-       laser->source = source;
+       if (laser)
+               laser->source = source;
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -294,12 +294,13 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                                 st.rotating = false;
                         }
                 }
-                else if (e.type == SDL_MOUSEBUTTONDOWN &&
-                                 e.button.button == SDL_BUTTON_RIGHT)
-                {
-                        if (st.edit_mode)
-                                st.rotating = true;
-                }
+               else if (e.type == SDL_MOUSEBUTTONDOWN &&
+                                e.button.button == SDL_BUTTON_RIGHT)
+               {
+                       if (st.edit_mode &&
+                           scene.objects[st.selected_obj]->rotatable)
+                               st.rotating = true;
+               }
                 else if (e.type == SDL_MOUSEBUTTONUP &&
                                  e.button.button == SDL_BUTTON_RIGHT)
                 {
@@ -427,24 +428,29 @@ void Renderer::handle_keyboard(RenderState &st, double dt,
 
                 double rot_speed = OBJECT_ROTATE_SPEED * dt;
                 bool changed = false;
-                if (state[SDL_SCANCODE_Q])
-                {
-                        scene.objects[st.selected_obj]->rotate(cam.forward, -rot_speed);
-                        if (scene.collides(st.selected_obj))
-                                scene.objects[st.selected_obj]->rotate(cam.forward,
-                                                                                                      rot_speed);
-                        else
-                                changed = true;
-                }
-                if (state[SDL_SCANCODE_E])
-                {
-                        scene.objects[st.selected_obj]->rotate(cam.forward, rot_speed);
-                        if (scene.collides(st.selected_obj))
-                                scene.objects[st.selected_obj]->rotate(cam.forward,
-                                                                                                      -rot_speed);
-                        else
-                                changed = true;
-                }
+               if (scene.objects[st.selected_obj]->rotatable)
+               {
+                       if (state[SDL_SCANCODE_Q])
+                       {
+                               scene.objects[st.selected_obj]->rotate(cam.forward,
+                                                                        -rot_speed);
+                               if (scene.collides(st.selected_obj))
+                                       scene.objects[st.selected_obj]->rotate(
+                                               cam.forward, rot_speed);
+                               else
+                                       changed = true;
+                       }
+                       if (state[SDL_SCANCODE_E])
+                       {
+                               scene.objects[st.selected_obj]->rotate(cam.forward,
+                                                                        rot_speed);
+                               if (scene.collides(st.selected_obj))
+                                       scene.objects[st.selected_obj]->rotate(
+                                               cam.forward, -rot_speed);
+                               else
+                                       changed = true;
+                       }
+               }
                 if (changed)
                 {
                         scene.update_beams(mats);


### PR DESCRIPTION
## Summary
- support optional `R`/`NR` flag when parsing beams
- respect beam rotatability in editor input handling
- track rotatability on base `Hittable` objects

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c6eb5a3e10832fa37d73451e0a8486