### PR TITLE
Add color filtering through transparent objects

### DIFF
--- a/inc/Beam.hpp
+++ b/inc/Beam.hpp
@@ -12,5 +12,6 @@ class Beam
        std::shared_ptr<BeamSource> source;
        Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                 double length, double intensity, int base_oid, int laser_mat,
-                int big_mat, int mid_mat, int small_mat, bool with_laser);
+                int big_mat, int mid_mat, int small_mat, bool with_laser,
+                const Vec3 &color);
 };

--- a/inc/Laser.hpp
+++ b/inc/Laser.hpp
@@ -5,14 +5,15 @@
 
 class Laser : public Hittable
 {
-	public:
+        public:
        Ray path;
        const double radius;
        double length;
-	double start;
-	double total_length;
-	double light_intensity;
-	std::weak_ptr<Hittable> source;
+        double start;
+        double total_length;
+        double light_intensity;
+        Vec3 color;
+        std::weak_ptr<Hittable> source;
        Laser(const Vec3 &origin, const Vec3 &dir, double length, double intensity,
                  int oid, int mid, double start = 0.0, double total = -1.0);
 

--- a/inc/LightRay.hpp
+++ b/inc/LightRay.hpp
@@ -7,8 +7,11 @@ class LightRay
         Ray ray;
        double radius;
        double intensity;
-       LightRay(const Vec3 &origin, const Vec3 &dir, double r, double intens)
-               : ray(origin, dir.normalized()), radius(r), intensity(intens)
+       Vec3 color;
+       LightRay(const Vec3 &origin, const Vec3 &dir, double r, double intens,
+                               const Vec3 &col)
+               : ray(origin, dir.normalized()), radius(r), intensity(intens),
+                 color(col)
        {
        }
 };

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -2,13 +2,15 @@
 
 Beam::Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                   double length, double intensity, int base_oid, int laser_mat,
-                  int big_mat, int mid_mat, int small_mat, bool with_laser)
+                  int big_mat, int mid_mat, int small_mat, bool with_laser,
+                  const Vec3 &color)
 {
-       light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity);
+       light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity, color);
        if (with_laser)
        {
                laser = std::make_shared<Laser>(origin, dir, length, intensity,
                                                                                base_oid, laser_mat);
+               laser->color = color;
                source = std::make_shared<BeamSource>(origin, dir, laser, light,
                                                                                 ray_radius, base_oid + 1,
                                                                                 big_mat, mid_mat, small_mat);

--- a/src/Laser.cpp
+++ b/src/Laser.cpp
@@ -5,7 +5,8 @@
 Laser::Laser(const Vec3 &origin, const Vec3 &dir, double len,
                          double intensity, int oid, int mid, double s, double total)
        : path(origin, dir.normalized()), radius(0.1), length(len), start(s),
-         total_length(total < 0 ? len : total), light_intensity(intensity)
+         total_length(total < 0 ? len : total), light_intensity(intensity),
+         color(1.0, 1.0, 1.0)
 {
         object_id = oid;
         material_id = mid;

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -315,7 +315,7 @@ static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid
                auto bm = std::make_shared<Beam>(o, dir_norm, ray_radius, L,
                                                                                         intensity, oid, beam_mat,
                                                                                         big_mat, mid_mat, small_mat,
-                                                                                        with_laser);
+                                                                                        with_laser, unit);
                 if (with_laser)
                 {
                         oid += 2;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -4,6 +4,7 @@
 #include "Settings.hpp"
 #include "Parser.hpp"
 #include "PauseMenu.hpp"
+#include "Laser.hpp"
 #include <SDL.h>
 #include <algorithm>
 #include <atomic>
@@ -17,32 +18,57 @@
 #include <string>
 #include <thread>
 
-static bool in_shadow(const Scene &scene, const std::vector<Material> &mats,
-					  const Vec3 &p, const PointLight &L)
+static inline Vec3 mix_colors(const Vec3 &a, const Vec3 &b, double alpha)
 {
-	Vec3 to_light = L.position - p;
-	double dist_to_light = to_light.length();
-	if (L.range > 0.0 && dist_to_light > L.range)
-		return false;
-	Vec3 dir = to_light.normalized();
-	Ray shadow_ray(p + dir * 1e-4, dir);
-	HitRecord tmp;
-	for (const auto &obj : scene.objects)
-	{
-		if (obj->is_beam())
-			continue;
-		if (std::find(L.ignore_ids.begin(), L.ignore_ids.end(),
-					  obj->object_id) != L.ignore_ids.end())
-			continue;
-		const Material &m = mats[obj->material_id];
-		if (m.alpha < 1.0)
-			continue;
-		if (obj->hit(shadow_ray, 1e-4, dist_to_light - 1e-4, tmp))
-		{
-			return true;
-		}
-	}
-	return false;
+        return a * (1.0 - alpha) + b * alpha;
+}
+
+static bool light_through(const Scene &scene, const std::vector<Material> &mats,
+                                                const Vec3 &p, const PointLight &L,
+                                                Vec3 &color, double &intensity)
+{
+        Vec3 to_light = L.position - p;
+        double dist_to_light = to_light.length();
+        if (L.range > 0.0 && dist_to_light > L.range)
+                return false;
+        Vec3 dir = to_light.normalized();
+        Ray shadow_ray(p + dir * 1e-4, dir);
+        double max_dist = dist_to_light - 1e-4;
+        color = L.color;
+        intensity = L.intensity;
+        while (max_dist > 1e-4)
+        {
+                HitRecord tmp;
+                bool hit_any = false;
+                double closest = max_dist;
+                int hit_mat = -1;
+                for (const auto &obj : scene.objects)
+                {
+                        if (obj->is_beam())
+                                continue;
+                        if (std::find(L.ignore_ids.begin(), L.ignore_ids.end(),
+                                                  obj->object_id) != L.ignore_ids.end())
+                                continue;
+                        if (obj->hit(shadow_ray, 1e-4, closest, tmp))
+                        {
+                                closest = tmp.t;
+                                hit_mat = tmp.material_id;
+                                hit_any = true;
+                        }
+                }
+                if (!hit_any)
+                        break;
+                const Material &m = mats[hit_mat];
+                if (m.alpha >= 1.0)
+                        return false;
+                color = mix_colors(color, m.base_color, m.alpha);
+                intensity *= (1.0 - m.alpha);
+                shadow_ray.orig = shadow_ray.orig + shadow_ray.dir * (closest + 1e-4);
+                max_dist -= closest + 1e-4;
+                if (intensity <= 1e-4)
+                        return false;
+        }
+        return true;
 }
 
 static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
@@ -57,10 +83,20 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
 	{
 		return Vec3(0.0, 0.0, 0.0);
 	}
-	const Material &m = mats[rec.material_id];
-	Vec3 eye = (r.dir * -1.0).normalized();
-	Vec3 base = m.base_color;
-	Vec3 col = m.color;
+        const Material &m = mats[rec.material_id];
+        Vec3 eye = (r.dir * -1.0).normalized();
+        Vec3 base = m.base_color;
+        Vec3 col = m.color;
+        if (rec.object_id >= 0 &&
+                rec.object_id < static_cast<int>(scene.objects.size()))
+        {
+                auto obj = scene.objects[rec.object_id];
+                if (obj->is_beam())
+                {
+                        auto beam = std::static_pointer_cast<Laser>(obj);
+                        base = col = beam->color;
+                }
+        }
 	if (m.checkered)
 	{
 		Vec3 inv = Vec3(1.0, 1.0, 1.0) - base;
@@ -78,34 +114,34 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
 		if (std::find(L.ignore_ids.begin(), L.ignore_ids.end(),
 					  rec.object_id) != L.ignore_ids.end())
 			continue;
-		Vec3 to_light = L.position - rec.p;
-		double dist = to_light.length();
-		if (L.range > 0.0 && dist > L.range)
-			continue;
-		Vec3 ldir = to_light / dist;
-		if (L.cutoff_cos > -1.0)
-		{
-			Vec3 spot_dir = (rec.p - L.position).normalized();
-			if (Vec3::dot(L.direction, spot_dir) < L.cutoff_cos)
-				continue;
-		}
-		if (in_shadow(scene, mats, rec.p, L))
-			continue;
-		double atten = 1.0;
-		if (L.range > 0.0)
-			atten = std::max(0.0, 1.0 - dist / L.range);
-		double diff = std::max(0.0, Vec3::dot(rec.normal, ldir));
-		Vec3 h = (ldir + eye).normalized();
-		double spec =
-			std::pow(std::max(0.0, Vec3::dot(rec.normal, h)), m.specular_exp) *
-			m.specular_k;
-		sum += Vec3(col.x * L.color.x * L.intensity * diff * atten +
-						L.color.x * spec * atten,
-					col.y * L.color.y * L.intensity * diff * atten +
-						L.color.y * spec * atten,
-					col.z * L.color.z * L.intensity * diff * atten +
-						L.color.z * spec * atten);
-	}
+                Vec3 to_light = L.position - rec.p;
+                double dist = to_light.length();
+                Vec3 ldir = to_light / dist;
+                if (L.cutoff_cos > -1.0)
+                {
+                        Vec3 spot_dir = (rec.p - L.position).normalized();
+                        if (Vec3::dot(L.direction, spot_dir) < L.cutoff_cos)
+                                continue;
+                }
+                Vec3 lcolor;
+                double lintensity;
+                if (!light_through(scene, mats, rec.p, L, lcolor, lintensity))
+                        continue;
+                double atten = 1.0;
+                if (L.range > 0.0)
+                        atten = std::max(0.0, 1.0 - dist / L.range);
+                double diff = std::max(0.0, Vec3::dot(rec.normal, ldir));
+                Vec3 h = (ldir + eye).normalized();
+                double spec =
+                        std::pow(std::max(0.0, Vec3::dot(rec.normal, h)), m.specular_exp) *
+                        m.specular_k;
+                sum += Vec3(col.x * lcolor.x * lintensity * diff * atten +
+                                                lcolor.x * spec * atten,
+                                        col.y * lcolor.y * lintensity * diff * atten +
+                                                lcolor.y * spec * atten,
+                                        col.z * lcolor.z * lintensity * diff * atten +
+                                                lcolor.z * spec * atten);
+        }
 	if (m.mirror)
 	{
 		Vec3 refl_dir =

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -120,7 +120,8 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                 if (hit_obj->shape_type() == ShapeType::BeamTarget)
                                         std::static_pointer_cast<BeamTarget>(hit_obj)->start_goal();
                         }
-                        if (mats[hit_rec.material_id].mirror)
+                        const Material &hit_mat = mats[hit_rec.material_id];
+                        if (hit_mat.mirror)
                         {
                                 double new_start = bm->start + closest;
                                 double new_len = bm->total_length - new_start;
@@ -132,6 +133,27 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                                refl_orig, refl_dir, new_len,
                                                bm->light_intensity, 0, bm->material_id,
                                                new_start, bm->total_length);
+                                        new_bm->color = bm->color;
+                                        new_bm->source = bm->source;
+                                        to_process.push_back(new_bm);
+                                        pending_lights.push_back({new_bm, hit_rec.object_id});
+                                }
+                        }
+                        else if (hit_mat.alpha < 1.0)
+                        {
+                                double new_start = bm->start + closest;
+                                double new_len = bm->total_length - new_start;
+                                if (new_len > 1e-4)
+                                {
+                                        Vec3 pass_orig = forward.at(closest) + forward.dir * 1e-4;
+                                        Vec3 new_color = bm->color * (1.0 - hit_mat.alpha) +
+                                                         hit_mat.base_color * hit_mat.alpha;
+                                        double new_intens =
+                                                bm->light_intensity * (1.0 - hit_mat.alpha);
+                                       auto new_bm = std::make_shared<Laser>(
+                                               pass_orig, forward.dir, new_len, new_intens, 0,
+                                               bm->material_id, new_start, bm->total_length);
+                                        new_bm->color = new_color;
                                         new_bm->source = bm->source;
                                         to_process.push_back(new_bm);
                                         pending_lights.push_back({new_bm, hit_rec.object_id});
@@ -143,7 +165,7 @@ void Scene::process_beams(const std::vector<Material> &mats,
         for (const auto &pl : pending_lights)
         {
                 auto bm = pl.beam;
-                Vec3 light_col = mats[bm->material_id].base_color;
+                Vec3 light_col = bm->color;
                 const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
                 double remain = bm->total_length - bm->start;
                 double ratio =


### PR DESCRIPTION
## Summary
- Tint beams and lights by blending their color with intervening material hues
- Continue beams through transparent shapes with mixed color and reduced intensity
- Shade surfaces using light filtered through semi-transparent objects

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68c7c438f0e0832f9bebc095508ac453