### PR TITLE
Add scorable flag to hittables and scene serialization

### DIFF
--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -35,10 +35,11 @@ class HitRecord
 
 class Hittable
 {
-	public:
-	bool movable = false;
-	int object_id = 0;
-	int material_id = 0;
+        public:
+        bool movable = false;
+        bool scorable = false;
+        int object_id = 0;
+        int material_id = 0;
 	virtual ~Hittable() = default;
 	virtual bool hit(const Ray &r, double tmin, double tmax,
 					 HitRecord &rec) const = 0;

--- a/scenes/test.rt
+++ b/scenes/test.rt
@@ -1,0 +1,34 @@
+#-----------CAMERA-------------
+C 2.21563,2.46000,-9.33447 -0.36065,-0.41687,0.83435 120
+
+#-----------LIGHTING-------------
+# Ambient light
+A 0.20000 255,255,255,255
+
+#-----------OBJECTS-------------
+#	Cone - lime, reflective, rotatable, movable
+co 2,0,0 0,-1,0 3 3 0,255,1,255 R M NS
+#	Sphere - red, reflective, rotatable, immovable
+sp -2,-0.40000,0 1 255,0,0,255 R IM S
+#	Cylinder - blue, transparent, non-reflective, rotatable, movable
+cy 0,3,0 0.70711,-0.70711,0 1 3 100,0,255,100 NR M NS
+#	Cube - silver, reflective, rotatable, movable
+cu 0,-5,0 0,1,0 2 2 2 200,200,200,255 R M NS
+
+#-----------WALLS-------------
+#	Plane - black, non-reflective, non-rotatable, immovable
+pl 0,-10,0 0,1,0 50,50,50,255 NR IM NS
+#	Plane - gray, non-reflective, non-rotatable, immovable
+pl -15,10,0 0,1,0 150,150,150,255 NR IM NS
+#	Plane - black, non-reflective, non-rotatable, immovable
+pl 0,-10,10 0,0,-1 50,50,50,255 NR IM NS
+#	Plane - green, non-reflective, non-rotatable, immovable
+pl -10,0,10 1,0,0 0,100,0,255 NR IM NS
+#	Plane - navy, non-reflective, non-rotatable, immovable
+pl 10,0,10 1,0,0 0,0,100,255 NR IM NS
+
+#-----------BEAMS-------------
+#	Beam source - fushsia, radius 0.40000, length 20, movable
+bm 0.75000 -3.56791,-0.22483,-7.45168 -0.00725,-0.04210,0.99909 255,0,255,255 0.40000 20 M
+#	Beam target - yellow, radius 0.40000, immovable
+bt 1.10000,1.10000,0 255,255,0,255 0.40000 IM

--- a/src/MapSaver.cpp
+++ b/src/MapSaver.cpp
@@ -161,7 +161,8 @@ std::string describe_shape(const Hittable &obj, const Material &mat)
                 oss << ", transparent";
         oss << ", " << (mat.mirror ? "reflective" : "non-reflective") << ", "
             << (is_rotatable(obj) ? "rotatable" : "non-rotatable") << ", "
-            << (obj.movable ? "movable" : "immovable");
+            << (obj.movable ? "movable" : "immovable") << ", "
+            << (obj.scorable ? "scorable" : "non-scorable");
         return oss.str();
 }
 
@@ -181,7 +182,8 @@ std::string describe_beam(const Laser &beam)
             << nearest_base16_color(beam.color) << ", radius "
             << format_double(beam.radius) << ", length "
             << format_double(beam.total_length >= 0.0 ? beam.total_length : beam.length)
-            << ", " << (movable ? "movable" : "immovable");
+            << ", " << (movable ? "movable" : "immovable") << ", "
+            << (beam.scorable ? "scorable" : "non-scorable");
         return oss.str();
 }
 
@@ -194,7 +196,8 @@ std::string describe_beam_target(const BeamTarget &target,
         if (inner.alpha < 0.999)
                 oss << ", transparent";
         oss << ", radius " << format_double(target.radius) << ", "
-            << (target.movable ? "movable" : "immovable");
+            << (target.movable ? "movable" : "immovable") << ", "
+            << (target.scorable ? "scorable" : "non-scorable");
         return oss.str();
 }
 
@@ -203,6 +206,7 @@ void write_shape_line(std::ostream &out, const Hittable &obj,
 {
         std::string reflective_flag = mat.mirror ? "R" : "NR";
         std::string move = obj.movable ? "M" : "IM";
+        std::string score = obj.scorable ? "S" : "NS";
         switch (obj.shape_type())
         {
         case ShapeType::Sphere:
@@ -210,7 +214,7 @@ void write_shape_line(std::ostream &out, const Hittable &obj,
                 const auto &sp = static_cast<const Sphere &>(obj);
                 out << "sp " << vec_to_str(sp.center) << ' ' << format_double(sp.radius) << ' '
                     << rgba_to_str(mat.base_color, mat.alpha) << ' ' << reflective_flag << ' '
-                    << move;
+                    << move << ' ' << score;
                 break;
         }
         case ShapeType::Plane:
@@ -218,7 +222,7 @@ void write_shape_line(std::ostream &out, const Hittable &obj,
                 const auto &pl = static_cast<const Plane &>(obj);
                 out << "pl " << vec_to_str(pl.point) << ' ' << vec_to_str(pl.normal) << ' '
                     << rgba_to_str(mat.base_color, mat.alpha) << ' ' << reflective_flag << ' '
-                    << move;
+                    << move << ' ' << score;
                 break;
         }
         case ShapeType::Cylinder:
@@ -227,7 +231,7 @@ void write_shape_line(std::ostream &out, const Hittable &obj,
                 out << "cy " << vec_to_str(cy.center) << ' ' << vec_to_str(cy.axis) << ' '
                     << format_double(cy.radius * 2.0) << ' ' << format_double(cy.height) << ' '
                     << rgba_to_str(mat.base_color, mat.alpha) << ' ' << reflective_flag << ' '
-                    << move;
+                    << move << ' ' << score;
                 break;
         }
         case ShapeType::Cube:
@@ -237,7 +241,7 @@ void write_shape_line(std::ostream &out, const Hittable &obj,
                     << format_double(cu.half.x * 2.0) << ' ' << format_double(cu.half.y * 2.0) << ' '
                     << format_double(cu.half.z * 2.0) << ' '
                     << rgba_to_str(mat.base_color, mat.alpha) << ' ' << reflective_flag << ' '
-                    << move;
+                    << move << ' ' << score;
                 break;
         }
         case ShapeType::Cone:
@@ -246,7 +250,7 @@ void write_shape_line(std::ostream &out, const Hittable &obj,
                 out << "co " << vec_to_str(co.center) << ' ' << vec_to_str(co.axis) << ' '
                     << format_double(co.radius * 2.0) << ' ' << format_double(co.height) << ' '
                     << rgba_to_str(mat.base_color, mat.alpha) << ' ' << reflective_flag << ' '
-                    << move;
+                    << move << ' ' << score;
                 break;
         }
         default:
@@ -261,7 +265,8 @@ void write_beam_target(std::ostream &out, const BeamTarget &bt,
         const Material &inner = mats[bt.inner.material_id];
         out << "bt " << vec_to_str(bt.center) << ' '
             << rgba_to_str(inner.base_color, inner.alpha) << ' '
-            << format_double(bt.radius) << ' ' << move;
+            << format_double(bt.radius) << ' ' << move << ' '
+            << (bt.scorable ? "S" : "NS");
 }
 
 void write_beam(std::ostream &out, const Laser &beam)
@@ -274,7 +279,7 @@ void write_beam(std::ostream &out, const Laser &beam)
             << vec_to_str(beam.path.orig) << ' ' << vec_to_str(beam.path.dir) << ' '
             << rgba_to_str(beam.color, 1.0) << ' ' << format_double(beam.radius) << ' '
             << format_double(beam.total_length >= 0.0 ? beam.total_length : beam.length) << ' '
-            << move;
+            << move << ' ' << (beam.scorable ? "S" : "NS");
 }
 
 } // namespace

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -155,6 +155,9 @@ static void parse_sphere(std::istringstream &iss, Scene &scene, int &oid, int &m
         std::string s_move;
         if (!(iss >> s_move))
                 s_move = "IM";
+        std::string s_score;
+        if (!(iss >> s_score))
+                s_score = "S";
         Vec3 c, rgb;
         double r = 1.0;
         double a = 255;
@@ -162,6 +165,7 @@ static void parse_sphere(std::istringstream &iss, Scene &scene, int &oid, int &m
         {
                 auto s = std::make_shared<Sphere>(c, r, oid++, mid);
                 s->movable = (s_move == "M");
+                s->scorable = (s_score == "S");
                 mats.emplace_back();
                 mats.back().color = rgb_to_unit(rgb);
                 mats.back().base_color = mats.back().color;
@@ -184,12 +188,16 @@ static void parse_plane(std::istringstream &iss, Scene &scene, int &oid, int &mi
         std::string s_move;
         if (!(iss >> s_move))
                 s_move = "IM";
+        std::string s_score;
+        if (!(iss >> s_score))
+                s_score = "S";
         Vec3 p, n, rgb;
         double a = 255;
         if (parse_triple(s_p, p) && parse_triple(s_n, n) && parse_rgba(s_rgb, rgb, a))
         {
                 auto pl = std::make_shared<Plane>(p, n, oid++, mid);
                 pl->movable = (s_move == "M");
+                pl->scorable = (s_score == "S");
                 mats.emplace_back();
                 mats.back().color = rgb_to_unit(rgb);
                 mats.back().base_color = mats.back().color;
@@ -212,6 +220,9 @@ static void parse_cylinder(std::istringstream &iss, Scene &scene, int &oid, int 
         std::string s_move;
         if (!(iss >> s_move))
                 s_move = "IM";
+        std::string s_score;
+        if (!(iss >> s_score))
+                s_score = "S";
         Vec3 c, dir, rgb;
         double d = 1.0, h = 1.0;
         double a = 255;
@@ -221,6 +232,7 @@ static void parse_cylinder(std::istringstream &iss, Scene &scene, int &oid, int 
                 auto cy =
                         std::make_shared<Cylinder>(c, dir, d / 2.0, h, oid++, mid);
                 cy->movable = (s_move == "M");
+                cy->scorable = (s_score == "S");
                 mats.emplace_back();
                 mats.back().color = rgb_to_unit(rgb);
                 mats.back().base_color = mats.back().color;
@@ -243,6 +255,9 @@ static void parse_cube(std::istringstream &iss, Scene &scene, int &oid, int &mid
         std::string s_move;
         if (!(iss >> s_move))
                 s_move = "IM";
+        std::string s_score;
+        if (!(iss >> s_score))
+                s_score = "S";
         Vec3 c, orient, rgb;
         double L = 1.0, W = 1.0, H = 1.0;
         double alpha = 255;
@@ -253,6 +268,7 @@ static void parse_cube(std::istringstream &iss, Scene &scene, int &oid, int &mid
                 auto cu =
                         std::make_shared<Cube>(c, orient, L, W, H, oid++, mid);
                 cu->movable = (s_move == "M");
+                cu->scorable = (s_score == "S");
                 mats.emplace_back();
                 mats.back().color = rgb_to_unit(rgb);
                 mats.back().base_color = mats.back().color;
@@ -275,12 +291,15 @@ static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid
         std::string s_laser;
         if (!(iss >> s_laser))
                 s_laser = "L";
+        std::string s_score;
+        if (!(iss >> s_score))
+                s_score = "S";
        Vec3 o, dir, rgb;
        double ray_radius = 0.1, L = 1.0, intensity = 0.75;
         double a = 255;
-       if (to_double(s_intens, intensity) && parse_triple(s_pos, o) &&
-               parse_triple(s_dir, dir) && parse_rgba(s_rgb, rgb, a) &&
-               to_double(s_r, ray_radius) && to_double(s_L, L))
+        if (to_double(s_intens, intensity) && parse_triple(s_pos, o) &&
+                parse_triple(s_dir, dir) && parse_rgba(s_rgb, rgb, a) &&
+                to_double(s_r, ray_radius) && to_double(s_L, L))
         {
                 Vec3 unit = rgb_to_unit(rgb);
                 mats.emplace_back();
@@ -315,10 +334,17 @@ static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid
                                                                                         intensity, oid, beam_mat,
                                                                                         big_mat, mid_mat, small_mat,
                                                                                         with_laser, unit);
+                bool scorable = (s_score == "S");
+                bool movable = (s_move == "M");
+                bm->source->movable = movable;
+                bm->source->scorable = scorable;
+                bm->source->mid.scorable = scorable;
+                bm->source->inner.scorable = scorable;
+                if (bm->laser)
+                        bm->laser->scorable = scorable;
                 if (with_laser)
                 {
                         oid += 2;
-                        bm->source->movable = (s_move == "M");
                         scene.objects.push_back(bm->laser);
                         scene.objects.push_back(bm->source);
                         const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
@@ -332,7 +358,6 @@ static void parse_beam(std::istringstream &iss, Scene &scene, int &oid, int &mid
                 else
                 {
                         oid += 1;
-                        bm->source->movable = (s_move == "M");
                         scene.objects.push_back(bm->source);
                         const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
                         scene.lights.emplace_back(
@@ -353,6 +378,9 @@ static void parse_beam_target(std::istringstream &iss, Scene &scene, int &oid,
         std::string s_move;
         if (!(iss >> s_move))
                 s_move = "IM";
+        std::string s_score;
+        if (!(iss >> s_score))
+                s_score = "S";
         Vec3 c, rgb;
         double R = 1.0;
         double a = 255;
@@ -380,6 +408,9 @@ static void parse_beam_target(std::istringstream &iss, Scene &scene, int &oid,
 
                 auto bt = std::make_shared<BeamTarget>(c, R, oid++, big_mat, mid_mat, small_mat);
                 bt->movable = (s_move == "M");
+                bt->scorable = (s_score == "S");
+                bt->mid.scorable = bt->scorable;
+                bt->inner.scorable = bt->scorable;
                 scene.objects.push_back(bt);
         }
 }
@@ -396,6 +427,9 @@ static void parse_cone(std::istringstream &iss, Scene &scene, int &oid, int &mid
         std::string s_move;
         if (!(iss >> s_move))
                 s_move = "IM";
+        std::string s_score;
+        if (!(iss >> s_score))
+                s_score = "S";
         Vec3 c, dir, rgb;
         double d = 1.0, h = 1.0;
         double a = 255;
@@ -405,6 +439,7 @@ static void parse_cone(std::istringstream &iss, Scene &scene, int &oid, int &mid
                 auto co =
                         std::make_shared<Cone>(c, dir, d / 2.0, h, oid++, mid);
                 co->movable = (s_move == "M");
+                co->scorable = (s_score == "S");
                 mats.emplace_back();
                 mats.back().color = rgb_to_unit(rgb);
                 mats.back().base_color = mats.back().color;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -118,7 +118,8 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                 hit_rec.object_id < static_cast<int>(objects.size()))
                         {
                                 auto hit_obj = objects[hit_rec.object_id];
-                                if (hit_obj->shape_type() == ShapeType::BeamTarget)
+                                if (hit_obj->shape_type() == ShapeType::BeamTarget &&
+                                        hit_obj->scorable)
                                         std::static_pointer_cast<BeamTarget>(hit_obj)->start_goal();
                         }
                         const Material &hit_mat = mats[hit_rec.material_id];
@@ -135,6 +136,7 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                                bm->light_intensity, 0, bm->material_id,
                                                new_start, bm->total_length);
                                         new_bm->color = bm->color;
+                                        new_bm->scorable = bm->scorable;
                                         new_bm->source = bm->source;
                                         to_process.push_back(new_bm);
                                         pending_lights.push_back({new_bm, hit_rec.object_id});
@@ -155,6 +157,7 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                                pass_orig, forward.dir, new_len, new_intens, 0,
                                                bm->material_id, new_start, bm->total_length);
                                         new_bm->color = new_color;
+                                        new_bm->scorable = bm->scorable;
                                         new_bm->source = bm->source;
                                         to_process.push_back(new_bm);
                                         pending_lights.push_back({new_bm, hit_rec.object_id});


### PR DESCRIPTION
## Summary
- add a scorable attribute to hittables and set it while parsing scene geometry
- persist the scorable flag when writing scenes and include it in object descriptions
- gate beam target scoring on the flag and propagate it to generated beam segments

## Testing
- cmake -S . -B build *(fails: missing SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2468f950832fa07d465f4e25cf80