### PR TITLE
Add beam light scoring system

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -36,9 +36,13 @@ class Scene
 	// Move object while preventing collisions.
 	Vec3 move_with_collision(int index, const Vec3 &delta);
 
-	// Move camera while avoiding obstacles.
+        // Move camera while avoiding obstacles.
         Vec3 move_camera(Camera &cam, const Vec3 &delta,
                                          const std::vector<Material> &materials) const;
+
+        // Compute the total score contributed by light rays hitting scorable objects.
+        double compute_score(const std::vector<Material> &materials,
+                                                 int samples_per_axis = 16) const;
         private:
         bool is_movable(int index) const;
         void apply_translation(const HittablePtr &object, const Vec3 &delta);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -713,6 +713,15 @@ void Renderer::render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex
         SDL_SetRenderDrawColor(ren, 255, 255, 255, 255);
         SDL_RenderClear(ren);
         SDL_RenderCopy(ren, tex, nullptr, nullptr);
+        double score_value = scene.compute_score(mats);
+        char score_buf[64];
+        std::snprintf(score_buf, sizeof(score_buf), "SCORE: %.5f", score_value);
+        SDL_Color white{255, 255, 255, 255};
+        const int score_scale = 2;
+        const int score_margin = 5;
+        CustomCharacter::draw_text(ren, score_buf, score_margin, score_margin, white,
+                                                           score_scale);
+        int overlay_start_y = score_margin + 7 * score_scale + 4;
         if (st.edit_mode && g_developer_mode)
         {
                 auto project = [&](const Vec3 &p, int &sx, int &sy) -> bool
@@ -791,7 +800,9 @@ void Renderer::render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex
                                          "MCLICK-DEL"};
                 for (int i = 0; i < 7; ++i)
                         CustomCharacter::draw_text(ren, legend[i], 5,
-                                                    5 + i * (7 * scale + 2), red, scale);
+                                                    overlay_start_y +
+                                                            i * (7 * scale + 2),
+                                                    red, scale);
                 std::string text = "DEVELOPER MODE";
                 int tw = CustomCharacter::text_width(text, scale);
                 CustomCharacter::draw_text(ren, text, W - tw - 5, 5, red, scale);


### PR DESCRIPTION
## Summary
- add scene scoring computation based on beam light coverage
- display the running score in the top-left corner of the renderer
- offset developer overlay to keep it clear of the score readout

## Testing
- cmake -S . -B build *(fails: missing SDL2 configuration files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc29c6a2a8832f9bf06baca2c80a40