### PR TITLE
Add beam scoring system and HUD display

### DIFF
--- a/inc/LightRay.hpp
+++ b/inc/LightRay.hpp
@@ -8,10 +8,11 @@ class LightRay
        double radius;
        double intensity;
        Vec3 color;
+       double length;
        LightRay(const Vec3 &origin, const Vec3 &dir, double r, double intens,
-                               const Vec3 &col)
+                               const Vec3 &col, double len)
                : ray(origin, dir.normalized()), radius(r), intensity(intens),
-                 color(col)
+                 color(col), length(len)
        {
        }
 };

--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -36,9 +36,12 @@ class Scene
 	// Move object while preventing collisions.
 	Vec3 move_with_collision(int index, const Vec3 &delta);
 
-	// Move camera while avoiding obstacles.
+        // Move camera while avoiding obstacles.
         Vec3 move_camera(Camera &cam, const Vec3 &delta,
                                          const std::vector<Material> &materials) const;
+
+        // Compute illuminated surface area score for active beams.
+        double compute_score() const;
         private:
         bool is_movable(int index) const;
         void apply_translation(const HittablePtr &object, const Vec3 &delta);
@@ -50,4 +53,16 @@ class Scene
                                                std::unordered_map<int, int> &id_map);
         void remap_light_ids(const std::unordered_map<int, int> &id_map);
         void reflect_lights(const std::vector<Material> &mats);
+
+        struct IlluminationSegment
+        {
+                Vec3 origin;
+                Vec3 dir;
+                double radius;
+                double length;
+                int source_id;
+        };
+        std::vector<IlluminationSegment> gather_illumination_segments() const;
+        bool score_ray_hit(const Ray &r, double tmin, double tmax, int ignore_id,
+                                           HitRecord &rec) const;
 };

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -5,7 +5,8 @@ Beam::Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                   int big_mat, int mid_mat, int small_mat, bool with_laser,
                   const Vec3 &color)
 {
-       light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity, color);
+	light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity, color,
+                                                                   length);
        if (with_laser)
        {
                laser = std::make_shared<Laser>(origin, dir, length, intensity,

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -187,6 +187,7 @@ struct Renderer::RenderState
         Vec3 edit_pos;
         int spawn_key = -1;
         double fps = 0.0;
+        double score = 0.0;
 };
 
 /// Initialize SDL window, renderer and texture objects.
@@ -713,6 +714,13 @@ void Renderer::render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex
         SDL_SetRenderDrawColor(ren, 255, 255, 255, 255);
         SDL_RenderClear(ren);
         SDL_RenderCopy(ren, tex, nullptr, nullptr);
+        SDL_Color score_color{255, 255, 255, 255};
+        const int score_scale = 2;
+        char score_buf[64];
+        std::snprintf(score_buf, sizeof(score_buf), "SCORE: %.5f", st.score);
+        CustomCharacter::draw_text(ren, score_buf, 5, 5, score_color,
+                                   score_scale);
+        int legend_base_y = 5 + 7 * score_scale + 10;
         if (st.edit_mode && g_developer_mode)
         {
                 auto project = [&](const Vec3 &p, int &sx, int &sy) -> bool
@@ -791,7 +799,9 @@ void Renderer::render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex
                                          "MCLICK-DEL"};
                 for (int i = 0; i < 7; ++i)
                         CustomCharacter::draw_text(ren, legend[i], 5,
-                                                    5 + i * (7 * scale + 2), red, scale);
+                                                    legend_base_y +
+                                                            i * (7 * scale + 2),
+                                                    red, scale);
                 std::string text = "DEVELOPER MODE";
                 int tw = CustomCharacter::text_width(text, scale);
                 CustomCharacter::draw_text(ren, text, W - tw - 5, 5, red, scale);
@@ -971,6 +981,7 @@ void Renderer::render_window(std::vector<Material> &mats,
                 handle_keyboard(st, dt, mats);
                 scene.update_goal_targets(dt, mats);
                 update_selection(st, mats);
+                st.score = scene.compute_score();
                 render_frame(st, ren, tex, framebuffer, pixels, RW, RH, W, H, T,
                                          mats);
         }


### PR DESCRIPTION
## Summary
- store the configured travel length on light rays and gather active illumination segments from lasers and light-only beam sources for scoring
- integrate a sampling-based surface scoring routine into `Scene::compute_score` and expose its result through the renderer state
- render the live SCORE HUD banner and push the developer legend below it to avoid overlap

## Testing
- cmake -S . -B build *(fails: missing SDL2 package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4060c1a4832f91b683a6023f901c