### PR TITLE
Prevent beam endpoints from casting shadows

### DIFF
--- a/inc/BeamSource.hpp
+++ b/inc/BeamSource.hpp
@@ -26,4 +26,5 @@ class BeamSource : public Sphere
         void rotate(const Vec3 &axis, double angle) override;
         Vec3 spot_direction() const override;
         bool blocks_when_transparent() const override { return true; }
+        bool casts_shadow() const override { return false; }
 };

--- a/inc/BeamTarget.hpp
+++ b/inc/BeamTarget.hpp
@@ -15,6 +15,7 @@ public:
     bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }
     void translate(const Vec3 &delta) override;
     bool blocks_when_transparent() const override { return true; }
+    bool casts_shadow() const override { return false; }
     ShapeType shape_type() const override { return ShapeType::BeamTarget; }
     void start_goal();
     void update_goal(double dt, std::vector<Material> &mats);

--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -49,8 +49,9 @@ class Hittable
         virtual bool is_plane() const { return false; }
         virtual bool is_bvh() const { return false; }
         virtual bool blocks_when_transparent() const { return false; }
+        virtual bool casts_shadow() const { return true; }
         // default translation does nothing
-	virtual void translate(const Vec3 &delta) { (void)delta; }
+        virtual void translate(const Vec3 &delta) { (void)delta; }
 	// default rotation does nothing
 	virtual void rotate(const Vec3 &axis, double angle)
 	{

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -49,6 +49,8 @@ static bool light_through(const Scene &scene, const std::vector<Material> &mats,
                 int hit_mat = -1;
                 for (const auto &obj : scene.objects)
                 {
+                        if (!obj->casts_shadow())
+                                continue;
                         if (obj->is_beam())
                                 continue;
                         if (std::find(L.ignore_ids.begin(), L.ignore_ids.end(),


### PR DESCRIPTION
## Summary
- add a casts_shadow() query to hittables so we can skip shadow casting objects
- mark beam sources and targets as not casting shadows
- update the renderer's shadow ray to respect the new flag

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd49276440832f8d973a013ba41456