### PR TITLE
Add developer mode auto-save and scene reload

### DIFF
--- a/inc/Renderer.hpp
+++ b/inc/Renderer.hpp
@@ -41,6 +41,12 @@ class Renderer
                                           std::vector<unsigned char> &pixels, int RW,
                                           int RH, int W, int H, int T,
                                           std::vector<Material> &mats);
+        void auto_save_if_needed(RenderState &st, const std::vector<Material> &mats,
+                                                        const std::string &scene_path);
+        void mark_scene_dirty(RenderState &st);
+        bool reload_scene(RenderState &st, std::vector<Material> &mats,
+                                                const std::string &scene_path, int width,
+                                                int height);
         Scene &scene;
         Camera &cam;
 };


### PR DESCRIPTION
## Summary
- track scene modifications in developer mode and mark the level dirty when objects or the camera change
- automatically persist dirty scenes using the existing MapSaver each frame
- add developer hotkey to reload the active scene from disk and reset editor state

## Testing
- `cmake -S . -B build` *(fails: missing SDL2 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4ad5c244832f8da2cd88354b003c