### PR TITLE
Allow developer mode to move any object

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -696,7 +696,8 @@ void Renderer::update_selection(RenderState &st,
                 Ray center_ray = cam.ray_through(0.5, 0.5);
                 HitRecord hrec;
                 if (scene.hit(center_ray, 1e-4, 1e9, hrec) &&
-                        scene.objects[hrec.object_id]->movable)
+                        (g_developer_mode ||
+                         scene.objects[hrec.object_id]->movable))
                 {
                         if (st.hover_mat != hrec.material_id)
                         {

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -348,17 +348,25 @@ Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
 // Determine whether object is movable.
 bool Scene::is_movable(int index) const
 {
-	if (index < 0 || index >= static_cast<int>(objects.size()))
-	{
-		return false;
-	}
-	HittablePtr object;
-	object = objects[index];
-	if (!object || object->is_beam())
-	{
-		return false;
-	}
-	return true;
+        if (index < 0 || index >= static_cast<int>(objects.size()))
+        {
+                return false;
+        }
+        HittablePtr object;
+        object = objects[index];
+        if (!object)
+        {
+                return false;
+        }
+        if (g_developer_mode)
+        {
+                return true;
+        }
+        if (object->is_beam())
+        {
+                return false;
+        }
+        return object->movable;
 }
 
 // Apply translation vector to given object.


### PR DESCRIPTION
## Summary
- allow developer mode to highlight and edit objects even when marked immovable
- respect object movability flags during normal play while granting developer-mode override

## Testing
- cmake -S . -B build *(fails: missing SDL2 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd686ba344832f9b36c22db6a6132b