### PR TITLE
Add beam source orientation cone

### DIFF
--- a/inc/BeamSource.hpp
+++ b/inc/BeamSource.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Cone.hpp"
 #include "Laser.hpp"
 #include "LightRay.hpp"
 #include "Sphere.hpp"
@@ -6,25 +7,30 @@
 
 class BeamSource : public Sphere
 {
-	public:
-	Sphere mid;
-	Sphere inner;
-       std::shared_ptr<Laser> beam;
-       std::shared_ptr<LightRay> light;
-       BeamSource(const Vec3 &c, const Vec3 &dir,
+        public:
+        Sphere mid;
+        Sphere inner;
+        Cone indicator;
+        std::shared_ptr<Laser> beam;
+        std::shared_ptr<LightRay> light;
+        BeamSource(const Vec3 &c, const Vec3 &dir,
                           const std::shared_ptr<Laser> &bm,
                           const std::shared_ptr<LightRay> &lt,
                           double mid_radius, int oid, int mat_big,
                           int mat_mid, int mat_small);
-	bool hit(const Ray &r, double tmin, double tmax,
-			 HitRecord &rec) const override;
-	bool bounding_box(AABB &out) const override
-	{
-		return Sphere::bounding_box(out);
-	}
+        bool hit(const Ray &r, double tmin, double tmax,
+                         HitRecord &rec) const override;
+        bool bounding_box(AABB &out) const override;
         void translate(const Vec3 &delta) override;
         void rotate(const Vec3 &axis, double angle) override;
         Vec3 spot_direction() const override;
         bool blocks_when_transparent() const override { return true; }
         bool casts_shadow() const override { return false; }
+
+        private:
+        static constexpr double kSpotlightLaserRatio = 20.0;
+        Vec3 fallback_direction;
+        double indicator_height;
+        double indicator_radius;
+        void update_indicator_geometry(const Vec3 &direction);
 };

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -1,6 +1,11 @@
 #include "BeamSource.hpp"
 #include <cmath>
 
+namespace
+{
+constexpr double kCapNormalThreshold = 1.0 - 1e-6;
+}
+
 BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
                                            const std::shared_ptr<Laser> &bm,
                                            const std::shared_ptr<LightRay> &lt,
@@ -8,15 +13,41 @@ BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
                                            int mat_mid, int mat_small)
        : Sphere(c, mid_radius * 2.0, oid, mat_big),
          mid(c, mid_radius * 1.5, -oid - 1, mat_mid),
-         inner(c, mid_radius, -oid - 2, mat_small), beam(bm), light(lt)
+         inner(c, mid_radius, -oid - 2, mat_small),
+         indicator([&]() {
+                 Vec3 direction = dir.length_squared() > 0.0 ? dir.normalized()
+                                                            : Vec3(0, 0, 1);
+                 double base_unit = mid_radius;
+                 if (bm)
+                         base_unit = bm->radius;
+                 else if (lt)
+                         base_unit = lt->radius;
+                 double height = mid_radius * 2.0;
+                 double radius = base_unit * kSpotlightLaserRatio;
+                 Vec3 axis = (-direction).normalized();
+                 Vec3 center_pos = c - axis * (height * 0.5);
+                 return Cone(center_pos, axis, radius, height, -oid - 3, mat_small);
+         }()),
+         beam(bm),
+         light(lt),
+         fallback_direction(dir.length_squared() > 0.0 ? dir.normalized()
+                                                       : Vec3(0, 0, 1)),
+         indicator_height(mid_radius * 2.0),
+         indicator_radius(((bm ? bm->radius
+                               : (lt ? lt->radius : mid_radius)) *
+                          kSpotlightLaserRatio))
 {
-        (void)dir;
+        if (fallback_direction.length_squared() == 0.0)
+                fallback_direction = Vec3(0, 0, 1);
+        if (!(indicator_radius > 0.0))
+                indicator_radius = indicator_height;
+        update_indicator_geometry(spot_direction());
 }
 
 bool BeamSource::hit(const Ray &r, double tmin, double tmax,
-					 HitRecord &rec) const
+                                         HitRecord &rec) const
 {
-	bool hit_any = false;
+        bool hit_any = false;
 	HitRecord tmp;
 	double closest = tmax;
 	if (Sphere::hit(r, tmin, closest, tmp))
@@ -33,26 +64,50 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax,
 	}
         if (inner.hit(r, tmin, closest, tmp))
         {
-                Vec3 beam_dir = beam
-                                        ? beam->path.dir
-                                        : (light ? light->ray.dir : Vec3(0, 0, 1));
+                Vec3 beam_dir = spot_direction();
                 Vec3 to_hit = (tmp.p - inner.center).normalized();
-		const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
-		if (Vec3::dot(beam_dir, to_hit) < hole_cos)
-		{
-			hit_any = true;
-			closest = tmp.t;
-			rec = tmp;
-		}
-	}
-	return hit_any;
+                const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+                if (Vec3::dot(beam_dir, to_hit) < hole_cos)
+                {
+                        hit_any = true;
+                        closest = tmp.t;
+                        rec = tmp;
+                }
+        }
+        if (indicator.hit(r, tmin, closest, tmp))
+        {
+                double dot = Vec3::dot(tmp.normal, indicator.axis);
+                if (dot > -kCapNormalThreshold)
+                {
+                        hit_any = true;
+                        closest = tmp.t;
+                        rec = tmp;
+                }
+        }
+        return hit_any;
+}
+
+bool BeamSource::bounding_box(AABB &out) const
+{
+        AABB outer_box;
+        if (!Sphere::bounding_box(outer_box))
+                return false;
+        AABB cone_box;
+        if (!indicator.bounding_box(cone_box))
+        {
+                out = outer_box;
+                return true;
+        }
+        out = AABB::surrounding_box(outer_box, cone_box);
+        return true;
 }
 
 void BeamSource::translate(const Vec3 &delta)
 {
-	Sphere::translate(delta);
-	mid.translate(delta);
-	inner.translate(delta);
+        Sphere::translate(delta);
+        mid.translate(delta);
+        inner.translate(delta);
+        indicator.translate(delta);
         if (beam)
                 beam->path.orig += delta;
         if (light)
@@ -73,6 +128,8 @@ void BeamSource::rotate(const Vec3 &ax, double angle)
         if (light)
                 light->ray.dir =
                         rotate_vec(light->ray.dir, ax, angle).normalized();
+        fallback_direction = rotate_vec(fallback_direction, ax, angle).normalized();
+        update_indicator_geometry(spot_direction());
 }
 
 Vec3 BeamSource::spot_direction() const
@@ -81,5 +138,17 @@ Vec3 BeamSource::spot_direction() const
                 return beam->path.dir;
         if (light)
                 return light->ray.dir;
-        return Vec3(0, 0, 1);
+        return fallback_direction;
+}
+
+void BeamSource::update_indicator_geometry(const Vec3 &direction)
+{
+        Vec3 dir = direction;
+        if (dir.length_squared() == 0.0)
+                dir = Vec3(0, 0, 1);
+        dir = dir.normalized();
+        indicator.axis = (-dir).normalized();
+        indicator.height = indicator_height;
+        indicator.radius = indicator_radius;
+        indicator.center = center - indicator.axis * (indicator.height * 0.5);
 }

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -804,6 +804,7 @@ bool process_beam_source(const TableData &table, Scene &scene, int &oid, int &mi
         beam->source->scorable = scorable_flag;
         beam->source->mid.scorable = scorable_flag;
         beam->source->inner.scorable = scorable_flag;
+        beam->source->indicator.scorable = scorable_flag;
         if (beam->laser)
                 beam->laser->scorable = scorable_flag;
         const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
@@ -822,7 +823,8 @@ bool process_beam_source(const TableData &table, Scene &scene, int &oid, int &mi
                 scene.lights.emplace_back(position, color_unit, intensity,
                                           std::vector<int>{beam->laser->object_id,
                                                            beam->source->object_id,
-                                                           beam->source->mid.object_id},
+                                                           beam->source->mid.object_id,
+                                                           beam->source->indicator.object_id},
                                           beam->source->object_id, dir_norm, cone_cos, length,
                                           false, true, spot_radius);
         }
@@ -832,7 +834,8 @@ bool process_beam_source(const TableData &table, Scene &scene, int &oid, int &mi
                 scene.objects.push_back(beam->source);
                 scene.lights.emplace_back(position, color_unit, intensity,
                                           std::vector<int>{beam->source->object_id,
-                                                           beam->source->mid.object_id},
+                                                           beam->source->mid.object_id,
+                                                           beam->source->indicator.object_id},
                                           beam->source->object_id, dir_norm, cone_cos, length,
                                           false, true, spot_radius);
         }


### PR DESCRIPTION
## Summary
- add a capless cone indicator to `BeamSource` so the beam orientation is visible
- update the beam source hit tests, transforms, and bounding box handling to include the cone
- propagate the new indicator through the parser so scoring and beam spotlight ignores stay accurate

## Testing
- cmake -S . -B build *(fails: SDL2 not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5200c484832f8deabaca8547f0ba