### PR TITLE
Add capless cone to beam source representation

### DIFF
--- a/inc/BeamSource.hpp
+++ b/inc/BeamSource.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Cone.hpp"
 #include "Laser.hpp"
 #include "LightRay.hpp"
 #include "Sphere.hpp"
@@ -6,9 +7,10 @@
 
 class BeamSource : public Sphere
 {
-	public:
-	Sphere mid;
-	Sphere inner;
+        public:
+        Sphere mid;
+        Sphere inner;
+        Cone cone;
        std::shared_ptr<Laser> beam;
        std::shared_ptr<LightRay> light;
        BeamSource(const Vec3 &c, const Vec3 &dir,
@@ -16,12 +18,9 @@ class BeamSource : public Sphere
                           const std::shared_ptr<LightRay> &lt,
                           double mid_radius, int oid, int mat_big,
                           int mat_mid, int mat_small);
-	bool hit(const Ray &r, double tmin, double tmax,
-			 HitRecord &rec) const override;
-	bool bounding_box(AABB &out) const override
-	{
-		return Sphere::bounding_box(out);
-	}
+        bool hit(const Ray &r, double tmin, double tmax,
+                         HitRecord &rec) const override;
+        bool bounding_box(AABB &out) const override;
         void translate(const Vec3 &delta) override;
         void rotate(const Vec3 &axis, double angle) override;
         Vec3 spot_direction() const override;

--- a/inc/Cone.hpp
+++ b/inc/Cone.hpp
@@ -4,15 +4,17 @@
 
 class Cone : public Hittable
 {
-	public:
-	Vec3 center;
-	Vec3 axis;
-	double radius;
-	double height;
-	Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid);
+        public:
+        Vec3 center;
+        Vec3 axis;
+        double radius;
+        double height;
+        bool capped;
+        Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid,
+              bool with_cap = true);
 
-	bool hit(const Ray &r, double tmin, double tmax,
-			 HitRecord &rec) const override;
+        bool hit(const Ray &r, double tmin, double tmax,
+                         HitRecord &rec) const override;
 	bool bounding_box(AABB &out) const override;
 	void translate(const Vec3 &delta) override { center += delta; }
 	void rotate(const Vec3 &axis, double angle) override;

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -1,6 +1,50 @@
 #include "BeamSource.hpp"
 #include <cmath>
 
+namespace
+{
+constexpr double kSpotlightLaserRatio = 20.0;
+
+Vec3 normalized_or_default(const Vec3 &dir)
+{
+        if (dir.length_squared() == 0.0)
+                return Vec3(0, 0, 1);
+        return dir.normalized();
+}
+
+double compute_cone_radius(double mid_radius,
+                                                  const std::shared_ptr<Laser> &beam,
+                                                  const std::shared_ptr<LightRay> &light)
+{
+        if (beam)
+                return beam->radius * kSpotlightLaserRatio;
+        if (light)
+                return light->radius * kSpotlightLaserRatio;
+        return mid_radius * kSpotlightLaserRatio;
+}
+
+Cone make_beam_cone(const Vec3 &origin, const Vec3 &dir, double outer_radius,
+                                        double mid_radius, int object_id, int material_id,
+                                        const std::shared_ptr<Laser> &beam,
+                                        const std::shared_ptr<LightRay> &light)
+{
+        Vec3 direction = normalized_or_default(dir);
+        double radius = compute_cone_radius(mid_radius, beam, light);
+        double height = outer_radius;
+        Vec3 axis = (-direction).normalized();
+        Vec3 cone_center = origin - axis * (height * 0.5);
+        return Cone(cone_center, axis, radius, height, object_id, material_id, false);
+}
+
+void align_cone(Cone &cone, const Vec3 &origin, const Vec3 &direction)
+{
+        Vec3 dir_norm = normalized_or_default(direction);
+        cone.axis = (-dir_norm).normalized();
+        double half_height = cone.height * 0.5;
+        cone.center = origin - cone.axis * half_height;
+}
+} // namespace
+
 BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
                                            const std::shared_ptr<Laser> &bm,
                                            const std::shared_ptr<LightRay> &lt,
@@ -8,13 +52,15 @@ BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
                                            int mat_mid, int mat_small)
        : Sphere(c, mid_radius * 2.0, oid, mat_big),
          mid(c, mid_radius * 1.5, -oid - 1, mat_mid),
-         inner(c, mid_radius, -oid - 2, mat_small), beam(bm), light(lt)
+         inner(c, mid_radius, -oid - 2, mat_small),
+         cone(make_beam_cone(c, dir, mid_radius * 2.0, mid_radius, -oid - 3,
+                                                 mat_mid, bm, lt)),
+         beam(bm), light(lt)
 {
-        (void)dir;
 }
 
 bool BeamSource::hit(const Ray &r, double tmin, double tmax,
-					 HitRecord &rec) const
+                                         HitRecord &rec) const
 {
 	bool hit_any = false;
 	HitRecord tmp;
@@ -25,34 +71,56 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax,
 		closest = tmp.t;
 		rec = tmp;
 	}
-	if (mid.hit(r, tmin, closest, tmp))
-	{
-		hit_any = true;
-		closest = tmp.t;
-		rec = tmp;
-	}
+        if (mid.hit(r, tmin, closest, tmp))
+        {
+                hit_any = true;
+                closest = tmp.t;
+                rec = tmp;
+        }
         if (inner.hit(r, tmin, closest, tmp))
         {
-                Vec3 beam_dir = beam
-                                        ? beam->path.dir
-                                        : (light ? light->ray.dir : Vec3(0, 0, 1));
+                Vec3 beam_dir = normalized_or_default(spot_direction());
                 Vec3 to_hit = (tmp.p - inner.center).normalized();
-		const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
-		if (Vec3::dot(beam_dir, to_hit) < hole_cos)
-		{
-			hit_any = true;
-			closest = tmp.t;
+                const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+                if (Vec3::dot(beam_dir, to_hit) < hole_cos)
+                {
+                        hit_any = true;
+                        closest = tmp.t;
 			rec = tmp;
 		}
-	}
-	return hit_any;
+        }
+        if (cone.hit(r, tmin, closest, tmp))
+        {
+                hit_any = true;
+                closest = tmp.t;
+                rec = tmp;
+        }
+        return hit_any;
+}
+
+bool BeamSource::bounding_box(AABB &out) const
+{
+        AABB outer_box;
+        if (!Sphere::bounding_box(outer_box))
+                return false;
+        AABB mid_box;
+        mid.bounding_box(mid_box);
+        outer_box = AABB::surrounding_box(outer_box, mid_box);
+        AABB inner_box;
+        inner.bounding_box(inner_box);
+        outer_box = AABB::surrounding_box(outer_box, inner_box);
+        AABB cone_box;
+        cone.bounding_box(cone_box);
+        out = AABB::surrounding_box(outer_box, cone_box);
+        return true;
 }
 
 void BeamSource::translate(const Vec3 &delta)
 {
-	Sphere::translate(delta);
-	mid.translate(delta);
-	inner.translate(delta);
+        Sphere::translate(delta);
+        mid.translate(delta);
+        inner.translate(delta);
+        cone.translate(delta);
         if (beam)
                 beam->path.orig += delta;
         if (light)
@@ -61,18 +129,21 @@ void BeamSource::translate(const Vec3 &delta)
 
 void BeamSource::rotate(const Vec3 &ax, double angle)
 {
-	auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
-	{
-		double c = std::cos(ang);
-		double s = std::sin(ang);
-		return v * c + Vec3::cross(axis, v) * s +
-			   axis * Vec3::dot(axis, v) * (1 - c);
-	};
+        auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
+        {
+                double c = std::cos(ang);
+                double s = std::sin(ang);
+                return v * c + Vec3::cross(axis, v) * s +
+                           axis * Vec3::dot(axis, v) * (1 - c);
+        };
+        Vec3 current_dir = spot_direction();
+        Vec3 rotated = rotate_vec(normalized_or_default(current_dir), ax, angle);
+        Vec3 new_dir = normalized_or_default(rotated);
         if (beam)
-                beam->path.dir = rotate_vec(beam->path.dir, ax, angle).normalized();
+                beam->path.dir = new_dir;
         if (light)
-                light->ray.dir =
-                        rotate_vec(light->ray.dir, ax, angle).normalized();
+                light->ray.dir = new_dir;
+        align_cone(cone, center, new_dir);
 }
 
 Vec3 BeamSource::spot_direction() const
@@ -81,5 +152,7 @@ Vec3 BeamSource::spot_direction() const
                 return beam->path.dir;
         if (light)
                 return light->ray.dir;
-        return Vec3(0, 0, 1);
+        if (cone.axis.length_squared() == 0.0)
+                return Vec3(0, 0, 1);
+        return (-cone.axis).normalized();
 }

--- a/src/Cone.cpp
+++ b/src/Cone.cpp
@@ -1,11 +1,12 @@
 #include "Cone.hpp"
 #include <cmath>
 
-Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid)
-	: center(c), axis(ax.normalized()), radius(r), height(h)
+Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid,
+           bool with_cap)
+        : center(c), axis(ax.normalized()), radius(r), height(h), capped(with_cap)
 {
-	object_id = oid;
-	material_id = mid;
+        object_id = oid;
+        material_id = mid;
 }
 
 bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
@@ -59,28 +60,32 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		}
 	}
 
-	Vec3 base_center = center - axis * (height * 0.5);
-	double denom = Vec3::dot(r.dir, (-1) * axis);
-	if (std::fabs(denom) > 1e-9)
-	{
-		double t = Vec3::dot(base_center - r.orig, (-1) * axis) / denom;
-		if (t >= tmin && t <= closest)
-		{
-			Vec3 p = r.at(t);
-			if ((p - base_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+        if (capped)
+        {
+                Vec3 base_center = center - axis * (height * 0.5);
+                double denom = Vec3::dot(r.dir, (-1) * axis);
+                if (std::fabs(denom) > 1e-9)
+                {
+                        double t = Vec3::dot(base_center - r.orig, (-1) * axis) /
+                                   denom;
+                        if (t >= tmin && t <= closest)
+                        {
+                                Vec3 p = r.at(t);
+                                if ((p - base_center).length_squared() <= radius * radius)
+                                {
+                                        rec.t = t;
+                                        rec.p = p;
+                                        rec.object_id = object_id;
+                                        rec.material_id = material_id;
+                                        rec.set_face_normal(r, (-1) * axis);
+                                        closest = t;
+                                        hit_any = true;
+                                }
+                        }
+                }
+        }
 
-	return hit_any;
+        return hit_any;
 }
 
 bool Cone::bounding_box(AABB &out) const

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -804,6 +804,7 @@ bool process_beam_source(const TableData &table, Scene &scene, int &oid, int &mi
         beam->source->scorable = scorable_flag;
         beam->source->mid.scorable = scorable_flag;
         beam->source->inner.scorable = scorable_flag;
+        beam->source->cone.scorable = scorable_flag;
         if (beam->laser)
                 beam->laser->scorable = scorable_flag;
         const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);


### PR DESCRIPTION
## Summary
- embed a capless cone inside the beam source to visualize beam orientation and update hit/transform handling accordingly
- allow cones to be created without a base cap and include the beam source cone in bounding box calculations
- ensure newly embedded geometry participates in scoring metadata during parsing

## Testing
- `cmake -S . -B build` *(fails: missing SDL2 package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5200c484832f8deabaca8547f0ba