### PR TITLE
Include reflected beam lights in scoring

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -465,7 +465,7 @@ double compute_beam_score(const Scene &scene, const std::vector<Material> &mats)
         double score = 0.0;
         for (const auto &L : scene.lights)
         {
-                if (!L.beam_spotlight || L.reflected)
+                if (!L.beam_spotlight)
                         continue;
                 score += integrate_spotlight_area(scene, mats, L);
         }


### PR DESCRIPTION
## Summary
- include reflected beam spotlights in the score calculation so targets hit by bounced beams contribute

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package)*

------
https://chatgpt.com/codex/tasks/task_e_68ce56e4ca10832f9b60651da2ac4a83