### PR TITLE
Add texture mapping support from XPM files

### DIFF
--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -23,14 +23,16 @@ class Material;
 class HitRecord
 {
 	public:
-	Vec3 p;
-	Vec3 normal;
-	double t;
-	int object_id;
-	int material_id;
-	bool front_face;
-	double beam_ratio = 0.0;
-	void set_face_normal(const Ray &r, const Vec3 &outward_normal);
+        Vec3 p;
+        Vec3 normal;
+        double t;
+        int object_id;
+        int material_id;
+        bool front_face;
+        double beam_ratio = 0.0;
+        double u = 0.0;
+        double v = 0.0;
+        void set_face_normal(const Ray &r, const Vec3 &outward_normal);
 };
 
 class Hittable

--- a/inc/Texture.hpp
+++ b/inc/Texture.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Vec3.hpp"
+#include <string>
+#include <vector>
+
+struct Texture
+{
+        int width = 0;
+        int height = 0;
+        std::vector<Vec3> data;
+
+        bool empty() const { return data.empty(); }
+        Vec3 sample(double u, double v) const;
+};
+
+bool load_xpm_texture(const std::string &path, Texture &out, std::string &error_message);

--- a/inc/material.hpp
+++ b/inc/material.hpp
@@ -1,24 +1,28 @@
 
 #pragma once
+#include "Texture.hpp"
 #include "Vec3.hpp"
 #include "light.hpp"
+#include <string>
 #include <vector>
 
 #define REFLECTION 50
 
 class Material
 {
-	public:
-	Vec3 color;		 // current color used for rendering
-	Vec3 base_color; // original color stored for edits
-	double alpha = 1.0;
-	double specular_exp = 50.0;
-	double specular_k = 0.5;
-	bool mirror = false;
-	bool random_alpha = false;
-	bool checkered = false; // render as checkered pattern when true
+        public:
+        Vec3 color;              // current color used for rendering
+        Vec3 base_color; // original color stored for edits
+        double alpha = 1.0;
+        double specular_exp = 50.0;
+        double specular_k = 0.5;
+        bool mirror = false;
+        bool random_alpha = false;
+        bool checkered = false; // render as checkered pattern when true
+        std::string texture_path;
+        Texture texture;
 };
 
 Vec3 phong(const Material &m, const Ambient &ambient,
-		   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,
-		   const Vec3 &eye);
+                   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,
+                   const Vec3 &eye);

--- a/scenes/level_1.toml
+++ b/scenes/level_1.toml
@@ -11,6 +11,7 @@ color = [255, 255, 255]
 [[objects.planes]]
 id = "plane1"
 color = [50, 50, 50]
+texture = "simple.xpm"
 position = [5.22401, -10.75213, -5.78879]
 dir = [0, 1, 0]
 reflective = false
@@ -22,6 +23,7 @@ transparent = false
 [[objects.planes]]
 id = "plane2"
 color = [150, 150, 150]
+texture = "simple.xpm"
 position = [-15, 10, 0]
 dir = [0, 1, 0]
 reflective = false
@@ -33,6 +35,7 @@ transparent = false
 [[objects.planes]]
 id = "plane3"
 color = [50, 50, 50]
+texture = "simple.xpm"
 position = [0, -10, 10]
 dir = [0, 0, -1]
 reflective = false
@@ -44,6 +47,7 @@ transparent = false
 [[objects.planes]]
 id = "plane4"
 color = [0, 100, 0]
+texture = "simple.xpm"
 position = [-10, 0, 10]
 dir = [1, 0, 0]
 reflective = false
@@ -55,6 +59,7 @@ transparent = false
 [[objects.planes]]
 id = "plane5"
 color = [0, 0, 100]
+texture = "simple.xpm"
 position = [10, 0, 10]
 dir = [1, 0, 0]
 reflective = false

--- a/src/Cone.cpp
+++ b/src/Cone.cpp
@@ -1,5 +1,38 @@
 #include "Cone.hpp"
+#include <algorithm>
 #include <cmath>
+
+namespace
+{
+
+void make_basis(const Vec3 &axis, Vec3 &u_axis, Vec3 &v_axis)
+{
+        Vec3 n = axis.normalized();
+        Vec3 helper = (std::fabs(n.x) > 0.9) ? Vec3(0, 1, 0) : Vec3(1, 0, 0);
+        u_axis = Vec3::cross(n, helper);
+        double len = u_axis.length();
+        if (len <= 1e-8)
+        {
+                helper = Vec3(0, 0, 1);
+                u_axis = Vec3::cross(n, helper);
+                len = u_axis.length();
+        }
+        if (len <= 1e-8)
+                u_axis = Vec3(1, 0, 0);
+        else
+                u_axis = u_axis / len;
+        v_axis = Vec3::cross(n, u_axis);
+}
+
+double wrap01(double value)
+{
+        double wrapped = value - std::floor(value);
+        if (wrapped < 0.0)
+                wrapped += 1.0;
+        return wrapped;
+}
+
+} // namespace
 
 Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid)
 	: center(c), axis(ax.normalized()), radius(r), height(h)
@@ -13,9 +46,12 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	bool hit_any = false;
 	double closest = tmax;
 
-	Vec3 apex = center + axis * (height * 0.5);
-	Vec3 down = (-1) * axis;
-	double k = radius / height;
+        Vec3 apex = center + axis * (height * 0.5);
+        Vec3 down = (-1) * axis;
+        double k = radius / height;
+        Vec3 basis_u;
+        Vec3 basis_v;
+        make_basis(axis, basis_u, basis_v);
 
 	Vec3 oc = r.orig - apex;
 	double oc_dot_d = Vec3::dot(oc, down);
@@ -48,16 +84,22 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 			double ax_dist = y;
 			Vec3 x_parallel = down * ax_dist;
 			Vec3 x_perp = (oc + root * r.dir) - x_parallel;
-			Vec3 normal = (x_perp - (k * k * ax_dist) * down).normalized();
-			rec.t = root;
-			rec.p = p;
-			rec.object_id = object_id;
-			rec.material_id = material_id;
-			rec.set_face_normal(r, normal);
-			closest = root;
-			hit_any = true;
-		}
-	}
+                        Vec3 normal = (x_perp - (k * k * ax_dist) * down).normalized();
+                        rec.t = root;
+                        rec.p = p;
+                        rec.object_id = object_id;
+                        rec.material_id = material_id;
+                        rec.set_face_normal(r, normal);
+                        Vec3 axis_point = apex + down * ax_dist;
+                        Vec3 radial_dir = (p - axis_point).normalized();
+                        double angle = std::atan2(Vec3::dot(radial_dir, basis_v),
+                                                  Vec3::dot(radial_dir, basis_u));
+                        rec.u = wrap01((angle + M_PI) / (2.0 * M_PI));
+                        rec.v = std::clamp(ax_dist / height, 0.0, 1.0);
+                        closest = root;
+                        hit_any = true;
+                }
+        }
 
 	Vec3 base_center = center - axis * (height * 0.5);
 	double denom = Vec3::dot(r.dir, (-1) * axis);
@@ -67,18 +109,23 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		if (t >= tmin && t <= closest)
 		{
 			Vec3 p = r.at(t);
-			if ((p - base_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                        if ((p - base_center).length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.set_face_normal(r, (-1) * axis);
+                                Vec3 diff = p - base_center;
+                                double u = Vec3::dot(diff, basis_u) / radius;
+                                double v = Vec3::dot(diff, basis_v) / radius;
+                                rec.u = std::clamp(u * 0.5 + 0.5, 0.0, 1.0);
+                                rec.v = std::clamp(v * 0.5 + 0.5, 0.0, 1.0);
+                                closest = t;
+                                hit_any = true;
+                        }
+                }
+        }
 
 	return hit_any;
 }

--- a/src/Cylinder.cpp
+++ b/src/Cylinder.cpp
@@ -1,5 +1,38 @@
 #include "Cylinder.hpp"
+#include <algorithm>
 #include <cmath>
+
+namespace
+{
+
+void make_basis(const Vec3 &axis, Vec3 &u_axis, Vec3 &v_axis)
+{
+        Vec3 n = axis.normalized();
+        Vec3 helper = (std::fabs(n.x) > 0.9) ? Vec3(0, 1, 0) : Vec3(1, 0, 0);
+        u_axis = Vec3::cross(n, helper);
+        double len = u_axis.length();
+        if (len <= 1e-8)
+        {
+                helper = Vec3(0, 0, 1);
+                u_axis = Vec3::cross(n, helper);
+                len = u_axis.length();
+        }
+        if (len <= 1e-8)
+                u_axis = Vec3(1, 0, 0);
+        else
+                u_axis = u_axis / len;
+        v_axis = Vec3::cross(n, u_axis);
+}
+
+double wrap01(double value)
+{
+        double wrapped = value - std::floor(value);
+        if (wrapped < 0.0)
+                wrapped += 1.0;
+        return wrapped;
+}
+
+} // namespace
 
 Cylinder::Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h,
 				   int oid, int mid)
@@ -14,12 +47,15 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	bool hit_any = false;
 	double closest = tmax;
 
-	Vec3 oc = r.orig - center;
-	double d_dot_a = Vec3::dot(r.dir, axis);
-	double oc_dot_a = Vec3::dot(oc, axis);
+        Vec3 oc = r.orig - center;
+        Vec3 basis_u;
+        Vec3 basis_v;
+        make_basis(axis, basis_u, basis_v);
+        double d_dot_a = Vec3::dot(r.dir, axis);
+        double oc_dot_a = Vec3::dot(oc, axis);
 
-	Vec3 d_perp = r.dir - d_dot_a * axis;
-	Vec3 oc_perp = oc - oc_dot_a * axis;
+        Vec3 d_perp = r.dir - d_dot_a * axis;
+        Vec3 oc_perp = oc - oc_dot_a * axis;
 
 	double A = Vec3::dot(d_perp, d_perp);
 	double B = 2 * Vec3::dot(d_perp, oc_perp);
@@ -42,42 +78,50 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 				continue;
 			}
 			Vec3 p = r.at(root);
-			Vec3 proj = center + axis * s;
-			Vec3 outward = (p - proj).normalized();
-			rec.t = root;
-			rec.p = p;
-			rec.object_id = object_id;
-			rec.material_id = material_id;
-			rec.beam_ratio = (s + height / 2) / height;
-			rec.set_face_normal(r, outward);
-			closest = root;
-			hit_any = true;
-		}
-	}
+                        Vec3 proj = center + axis * s;
+                        Vec3 outward = (p - proj).normalized();
+                        rec.t = root;
+                        rec.p = p;
+                        rec.object_id = object_id;
+                        rec.material_id = material_id;
+                        rec.beam_ratio = (s + height / 2) / height;
+                        rec.set_face_normal(r, outward);
+                        double u = std::atan2(Vec3::dot(outward, basis_v), Vec3::dot(outward, basis_u));
+                        rec.u = wrap01((u + M_PI) / (2.0 * M_PI));
+                        rec.v = std::clamp((s + height / 2) / height, 0.0, 1.0);
+                        closest = root;
+                        hit_any = true;
+                }
+        }
 
-	Vec3 top_center = center + axis * (height / 2);
-	Vec3 bottom_center = center - axis * (height / 2);
+        Vec3 top_center = center + axis * (height / 2);
+        Vec3 bottom_center = center - axis * (height / 2);
 
-	double denom_top = Vec3::dot(r.dir, axis);
-	if (std::fabs(denom_top) > 1e-9)
-	{
-		double t = Vec3::dot(top_center - r.orig, axis) / denom_top;
-		if (t >= tmin && t <= closest)
-		{
-			Vec3 p = r.at(t);
-			if ((p - top_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.beam_ratio = 1.0;
-				rec.set_face_normal(r, axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+        double denom_top = Vec3::dot(r.dir, axis);
+        if (std::fabs(denom_top) > 1e-9)
+        {
+                double t = Vec3::dot(top_center - r.orig, axis) / denom_top;
+                if (t >= tmin && t <= closest)
+                {
+                        Vec3 p = r.at(t);
+                        if ((p - top_center).length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.beam_ratio = 1.0;
+                                rec.set_face_normal(r, axis);
+                                Vec3 diff = p - top_center;
+                                double u = Vec3::dot(diff, basis_u) / radius;
+                                double v = Vec3::dot(diff, basis_v) / radius;
+                                rec.u = std::clamp(u * 0.5 + 0.5, 0.0, 1.0);
+                                rec.v = std::clamp(1.0 - (v * 0.5 + 0.5), 0.0, 1.0);
+                                closest = t;
+                                hit_any = true;
+                        }
+                }
+        }
 
 	double denom_bot = Vec3::dot(r.dir, (-1) * axis);
 	if (std::fabs(denom_bot) > 1e-9)
@@ -86,19 +130,24 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		if (t >= tmin && t <= closest)
 		{
 			Vec3 p = r.at(t);
-			if ((p - bottom_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.beam_ratio = 0.0;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                        if ((p - bottom_center).length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.beam_ratio = 0.0;
+                                rec.set_face_normal(r, (-1) * axis);
+                                Vec3 diff = p - bottom_center;
+                                double u = Vec3::dot(diff, basis_u) / radius;
+                                double v = Vec3::dot(diff, basis_v) / radius;
+                                rec.u = std::clamp(u * 0.5 + 0.5, 0.0, 1.0);
+                                rec.v = std::clamp(v * 0.5 + 0.5, 0.0, 1.0);
+                                closest = t;
+                                hit_any = true;
+                        }
+                }
+        }
 
 	return hit_any;
 }

--- a/src/MapSaver.cpp
+++ b/src/MapSaver.cpp
@@ -200,7 +200,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(false) << "\n";
                 out << "movable = " << bool_str(rec.plane->movable) << "\n";
                 out << "scorable = " << bool_str(rec.plane->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cube_index = 1;
@@ -218,7 +221,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cube)) << "\n";
                 out << "movable = " << bool_str(rec.cube->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cube->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int sphere_index = 1;
@@ -234,7 +240,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.sphere)) << "\n";
                 out << "movable = " << bool_str(rec.sphere->movable) << "\n";
                 out << "scorable = " << bool_str(rec.sphere->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cone_index = 1;
@@ -251,7 +260,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cone)) << "\n";
                 out << "movable = " << bool_str(rec.cone->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cone->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cylinder_index = 1;
@@ -268,7 +280,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cylinder)) << "\n";
                 out << "movable = " << bool_str(rec.cylinder->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cylinder->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int beam_source_index = 1;

--- a/src/Sphere.cpp
+++ b/src/Sphere.cpp
@@ -1,4 +1,5 @@
 #include "Sphere.hpp"
+#include <algorithm>
 #include <cmath>
 
 Sphere::Sphere(const Vec3 &c, double r, int oid, int mid) : center(c), radius(r)
@@ -30,12 +31,16 @@ bool Sphere::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		}
 	}
 	rec.t = root;
-	rec.p = r.at(rec.t);
-	rec.material_id = material_id;
-	rec.object_id = object_id;
-	Vec3 outward = (rec.p - center) / radius;
-	rec.set_face_normal(r, outward);
-	return true;
+        rec.p = r.at(rec.t);
+        rec.material_id = material_id;
+        rec.object_id = object_id;
+        Vec3 outward = (rec.p - center) / radius;
+        rec.set_face_normal(r, outward);
+        double phi = std::atan2(outward.z, outward.x);
+        double theta = std::acos(std::clamp(outward.y, -1.0, 1.0));
+        rec.u = (phi + M_PI) / (2.0 * M_PI);
+        rec.v = theta / M_PI;
+        return true;
 }
 
 bool Sphere::bounding_box(AABB &out) const

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -1,0 +1,262 @@
+#include "Texture.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+namespace
+{
+
+std::string trim(const std::string &value)
+{
+        size_t start = 0;
+        while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start])))
+                ++start;
+        size_t end = value.size();
+        while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1])))
+                --end;
+        return value.substr(start, end - start);
+}
+
+bool parse_hex_color(const std::string &token, Vec3 &out)
+{
+        if (token.size() != 7 || token[0] != '#')
+                return false;
+        auto hex_value = [](char c) -> int {
+                if (c >= '0' && c <= '9')
+                        return c - '0';
+                if (c >= 'a' && c <= 'f')
+                        return 10 + (c - 'a');
+                if (c >= 'A' && c <= 'F')
+                        return 10 + (c - 'A');
+                return -1;
+        };
+        int components[3] = {0, 0, 0};
+        for (int i = 0; i < 3; ++i)
+        {
+                int hi = hex_value(token[1 + i * 2]);
+                int lo = hex_value(token[2 + i * 2]);
+                if (hi < 0 || lo < 0)
+                        return false;
+                components[i] = hi * 16 + lo;
+        }
+        out = Vec3(components[0] / 255.0, components[1] / 255.0, components[2] / 255.0);
+        return true;
+}
+
+bool parse_named_color(const std::string &token, Vec3 &out)
+{
+        static const std::unordered_map<std::string, Vec3> kNamed{
+                {"black", Vec3(0.0, 0.0, 0.0)},
+                {"white", Vec3(1.0, 1.0, 1.0)},
+                {"red", Vec3(1.0, 0.0, 0.0)},
+                {"green", Vec3(0.0, 1.0, 0.0)},
+                {"blue", Vec3(0.0, 0.0, 1.0)},
+                {"yellow", Vec3(1.0, 1.0, 0.0)},
+                {"magenta", Vec3(1.0, 0.0, 1.0)},
+                {"cyan", Vec3(0.0, 1.0, 1.0)},
+                {"gray", Vec3(0.5, 0.5, 0.5)},
+                {"grey", Vec3(0.5, 0.5, 0.5)},
+        };
+        auto it = kNamed.find(token);
+        if (it == kNamed.end())
+                return false;
+        out = it->second;
+        return true;
+}
+
+Vec3 parse_color_token(const std::string &token)
+{
+        Vec3 color(0.0, 0.0, 0.0);
+        if (token == "None" || token == "none")
+                return color;
+        if (parse_hex_color(token, color))
+                return color;
+        if (parse_named_color(token, color))
+                return color;
+        return color;
+}
+
+bool extract_string_line(const std::string &line, std::string &out)
+{
+        size_t first = line.find('"');
+        if (first == std::string::npos)
+                return false;
+        size_t last = line.find('"', first + 1);
+        if (last == std::string::npos)
+                return false;
+        out = line.substr(first + 1, last - first - 1);
+        return true;
+}
+
+} // namespace
+
+Vec3 Texture::sample(double u, double v) const
+{
+        if (data.empty() || width <= 0 || height <= 0)
+                return Vec3(0.0, 0.0, 0.0);
+        if (!std::isfinite(u) || !std::isfinite(v))
+                return Vec3(0.0, 0.0, 0.0);
+        double u_wrapped = u - std::floor(u);
+        double v_wrapped = v - std::floor(v);
+        if (u_wrapped < 0.0)
+                u_wrapped += 1.0;
+        if (v_wrapped < 0.0)
+                v_wrapped += 1.0;
+        int x = static_cast<int>(u_wrapped * static_cast<double>(width));
+        int y = static_cast<int>((1.0 - v_wrapped) * static_cast<double>(height));
+        if (x < 0)
+                x = 0;
+        if (x >= width)
+                x = width - 1;
+        if (y < 0)
+                y = 0;
+        if (y >= height)
+                y = height - 1;
+        return data[static_cast<size_t>(y) * static_cast<size_t>(width) + static_cast<size_t>(x)];
+}
+
+bool load_xpm_texture(const std::string &path, Texture &out, std::string &error_message)
+{
+        std::ifstream in(path);
+        if (!in)
+        {
+                error_message = "cannot open file";
+                return false;
+        }
+
+        std::vector<std::string> lines;
+        std::string line;
+        while (std::getline(in, line))
+        {
+                std::string extracted;
+                if (!extract_string_line(line, extracted))
+                        continue;
+                lines.push_back(extracted);
+        }
+
+        if (lines.empty())
+        {
+                error_message = "missing XPM data";
+                return false;
+        }
+
+        std::istringstream header_stream(lines[0]);
+        int width = 0;
+        int height = 0;
+        int num_colors = 0;
+        int chars_per_pixel = 0;
+        if (!(header_stream >> width >> height >> num_colors >> chars_per_pixel))
+        {
+                error_message = "invalid header";
+                return false;
+        }
+        if (width <= 0 || height <= 0 || num_colors <= 0 || chars_per_pixel <= 0)
+        {
+                error_message = "invalid dimensions";
+                return false;
+        }
+        if (static_cast<int>(lines.size()) < 1 + num_colors + height)
+        {
+                error_message = "incomplete XPM data";
+                return false;
+        }
+
+        std::unordered_map<std::string, Vec3> palette;
+        palette.reserve(static_cast<size_t>(num_colors));
+        for (int i = 0; i < num_colors; ++i)
+        {
+                const std::string &entry = lines[1 + i];
+                if (static_cast<int>(entry.size()) < chars_per_pixel)
+                {
+                        error_message = "invalid color entry";
+                        return false;
+                }
+                std::string key = entry.substr(0, static_cast<size_t>(chars_per_pixel));
+                std::string rest = trim(entry.substr(static_cast<size_t>(chars_per_pixel)));
+                std::istringstream rest_stream(rest);
+                std::string token;
+                bool color_found = false;
+                while (rest_stream >> token)
+                {
+                        if (token == "c" || token == "c#")
+                        {
+                                std::string value;
+                                if (!(rest_stream >> value))
+                                {
+                                        error_message = "missing color value";
+                                        return false;
+                                }
+                                palette[key] = parse_color_token(value);
+                                color_found = true;
+                                break;
+                        }
+                        if (token.size() == 1 && token[0] == 'c')
+                        {
+                                std::string value;
+                                if (!(rest_stream >> value))
+                                {
+                                        error_message = "missing color value";
+                                        return false;
+                                }
+                                palette[key] = parse_color_token(value);
+                                color_found = true;
+                                break;
+                        }
+                }
+                if (!color_found)
+                {
+                        // Some XPM variants have the color value immediately after 'c'
+                        size_t pos = rest.find('c');
+                        if (pos != std::string::npos)
+                        {
+                                std::string value = trim(rest.substr(pos + 1));
+                                std::istringstream value_stream(value);
+                                std::string first;
+                                if (value_stream >> first)
+                                {
+                                        palette[key] = parse_color_token(first);
+                                        color_found = true;
+                                }
+                        }
+                }
+                if (!color_found)
+                {
+                        error_message = "color entry missing 'c' definition";
+                        return false;
+                }
+        }
+
+        out.width = width;
+        out.height = height;
+        out.data.assign(static_cast<size_t>(width * height), Vec3(0.0, 0.0, 0.0));
+
+        for (int row = 0; row < height; ++row)
+        {
+                const std::string &data_line = lines[1 + num_colors + row];
+                if (static_cast<int>(data_line.size()) < width * chars_per_pixel)
+                {
+                        error_message = "pixel row too short";
+                        return false;
+                }
+                for (int col = 0; col < width; ++col)
+                {
+                        size_t pos = static_cast<size_t>(col * chars_per_pixel);
+                        std::string key = data_line.substr(pos, static_cast<size_t>(chars_per_pixel));
+                        auto it = palette.find(key);
+                        if (it == palette.end())
+                        {
+                                error_message = "pixel references undefined color";
+                                return false;
+                        }
+                        out.data[static_cast<size_t>(row) * static_cast<size_t>(width) + static_cast<size_t>(col)] =
+                                it->second;
+                }
+        }
+
+        return true;
+}

--- a/textures/simple.xpm
+++ b/textures/simple.xpm
@@ -1,0 +1,10 @@
+/* XPM */
+static char * simple_xpm[] = {
+"4 4 2 1",
+". c #FF7F00",
+"X c #0040FF",
+".X.X",
+"X.X.",
+".X.X",
+"X.X."
+};


### PR DESCRIPTION
## Summary
- add texture loading utilities and material support for XPM-based textures
- extend scene parsing, shapes, and rendering logic to map textures onto planes, spheres, cubes, cones, and cylinders
- update scene serialization to preserve texture references and adjust editor interactions for textured objects

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5d1c6bd4832f9f9eafa4e8b9c4e0