### PR TITLE
Add texture support with XPM loader and UV mapping

### DIFF
--- a/inc/Cone.hpp
+++ b/inc/Cone.hpp
@@ -5,11 +5,13 @@
 class Cone : public Hittable
 {
 	public:
-	Vec3 center;
-	Vec3 axis;
-	double radius;
-	double height;
-	Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid);
+        Vec3 center;
+        Vec3 axis;
+        double radius;
+        double height;
+        Vec3 tangent;
+        Vec3 bitangent;
+        Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid);
 
 	bool hit(const Ray &r, double tmin, double tmax,
 			 HitRecord &rec) const override;

--- a/inc/Cylinder.hpp
+++ b/inc/Cylinder.hpp
@@ -5,12 +5,14 @@
 class Cylinder : public Hittable
 {
 	public:
-	Vec3 center;
-	Vec3 axis;
-	double radius;
-	double height;
-	Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h, int oid,
-			 int mid);
+        Vec3 center;
+        Vec3 axis;
+        double radius;
+        double height;
+        Vec3 tangent;
+        Vec3 bitangent;
+        Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h, int oid,
+                         int mid);
 
 	bool hit(const Ray &r, double tmin, double tmax,
 			 HitRecord &rec) const override;

--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -22,15 +22,17 @@ class Material;
 
 class HitRecord
 {
-	public:
-	Vec3 p;
-	Vec3 normal;
-	double t;
-	int object_id;
-	int material_id;
-	bool front_face;
-	double beam_ratio = 0.0;
-	void set_face_normal(const Ray &r, const Vec3 &outward_normal);
+        public:
+        Vec3 p;
+        Vec3 normal;
+        double t;
+        int object_id;
+        int material_id;
+        bool front_face;
+        double beam_ratio = 0.0;
+        double u = 0.0;
+        double v = 0.0;
+        void set_face_normal(const Ray &r, const Vec3 &outward_normal);
 };
 
 class Hittable

--- a/inc/Plane.hpp
+++ b/inc/Plane.hpp
@@ -4,10 +4,12 @@
 
 class Plane : public Hittable
 {
-	public:
-	Vec3 point;
-	Vec3 normal;
-	Plane(const Vec3 &p, const Vec3 &n, int oid, int mid);
+        public:
+        Vec3 point;
+        Vec3 normal;
+        Vec3 u_axis;
+        Vec3 v_axis;
+        Plane(const Vec3 &p, const Vec3 &n, int oid, int mid);
 
 	bool hit(const Ray &r, double tmin, double tmax,
 			 HitRecord &rec) const override;

--- a/inc/Texture.hpp
+++ b/inc/Texture.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "Vec3.hpp"
+#include <string>
+#include <vector>
+
+struct Texture
+{
+        int width = 0;
+        int height = 0;
+        std::vector<Vec3> pixels;
+        bool valid() const { return width > 0 && height > 0 && pixels.size() == static_cast<size_t>(width * height); }
+        Vec3 sample(double u, double v) const;
+};
+
+bool load_xpm_texture(const std::string &path, Texture &out, std::string &error);

--- a/inc/material.hpp
+++ b/inc/material.hpp
@@ -1,24 +1,31 @@
-
 #pragma once
 #include "Vec3.hpp"
 #include "light.hpp"
+#include <memory>
 #include <vector>
 
 #define REFLECTION 50
 
+class Texture;
+class HitRecord;
+
 class Material
 {
-	public:
-	Vec3 color;		 // current color used for rendering
-	Vec3 base_color; // original color stored for edits
-	double alpha = 1.0;
-	double specular_exp = 50.0;
-	double specular_k = 0.5;
-	bool mirror = false;
-	bool random_alpha = false;
-	bool checkered = false; // render as checkered pattern when true
+        public:
+        Vec3 color;              // current color used for rendering
+        Vec3 base_color; // original color stored for edits
+        double alpha = 1.0;
+        double specular_exp = 50.0;
+        double specular_k = 0.5;
+        bool mirror = false;
+        bool random_alpha = false;
+        bool checkered = false; // render as checkered pattern when true
+        std::shared_ptr<Texture> texture;
 };
 
 Vec3 phong(const Material &m, const Ambient &ambient,
-		   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,
-		   const Vec3 &eye);
+                   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,
+                   const Vec3 &eye);
+
+Vec3 material_color_at(const Material &m, const HitRecord &rec);
+Vec3 material_base_color_at(const Material &m, const HitRecord &rec);

--- a/src/Cube.cpp
+++ b/src/Cube.cpp
@@ -56,10 +56,46 @@ bool Cube::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	rec.material_id = material_id;
 	rec.object_id = object_id;
 
-	Vec3 normal_world = normal_local.x * axis[0] + normal_local.y * axis[1] +
-						normal_local.z * axis[2];
-	rec.set_face_normal(r, normal_world);
-	return true;
+        Vec3 normal_world = normal_local.x * axis[0] + normal_local.y * axis[1] +
+                                                normal_local.z * axis[2];
+        rec.set_face_normal(r, normal_world);
+        Vec3 local_point(Vec3::dot(rec.p - center, axis[0]),
+                                         Vec3::dot(rec.p - center, axis[1]),
+                                         Vec3::dot(rec.p - center, axis[2]));
+        double u = 0.0;
+        double v = 0.0;
+        if (std::fabs(normal_local.x) > 0.5)
+        {
+                double inv_w = (half.z > 1e-12) ? (1.0 / (2.0 * half.z)) : 0.0;
+                double inv_h = (half.y > 1e-12) ? (1.0 / (2.0 * half.y)) : 0.0;
+                u = local_point.z * inv_w + 0.5;
+                v = local_point.y * inv_h + 0.5;
+                if (normal_local.x < 0)
+                        u = 1.0 - u;
+        }
+        else if (std::fabs(normal_local.y) > 0.5)
+        {
+                double inv_l = (half.x > 1e-12) ? (1.0 / (2.0 * half.x)) : 0.0;
+                double inv_w = (half.z > 1e-12) ? (1.0 / (2.0 * half.z)) : 0.0;
+                u = local_point.x * inv_l + 0.5;
+                v = local_point.z * inv_w + 0.5;
+                if (normal_local.y > 0)
+                        v = 1.0 - v;
+                else
+                        u = 1.0 - u;
+        }
+        else
+        {
+                double inv_l = (half.x > 1e-12) ? (1.0 / (2.0 * half.x)) : 0.0;
+                double inv_h = (half.y > 1e-12) ? (1.0 / (2.0 * half.y)) : 0.0;
+                u = local_point.x * inv_l + 0.5;
+                v = local_point.y * inv_h + 0.5;
+                if (normal_local.z < 0)
+                        u = 1.0 - u;
+        }
+        rec.u = std::clamp(u, 0.0, 1.0);
+        rec.v = std::clamp(v, 0.0, 1.0);
+        return true;
 }
 
 bool Cube::bounding_box(AABB &out) const

--- a/src/Cylinder.cpp
+++ b/src/Cylinder.cpp
@@ -1,22 +1,69 @@
 #include "Cylinder.hpp"
+#include <algorithm>
 #include <cmath>
 
-Cylinder::Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h,
-				   int oid, int mid)
-	: center(c), axis(axis_.normalized()), radius(r), height(h)
+namespace
 {
-	object_id = oid;
-	material_id = mid;
+
+void build_basis(const Vec3 &axis, Vec3 &tangent, Vec3 &bitangent)
+{
+        Vec3 helper = (std::fabs(axis.z) < 0.999) ? Vec3(0, 0, 1) : Vec3(0, 1, 0);
+        tangent = Vec3::cross(helper, axis);
+        double len = tangent.length();
+        if (len <= 1e-12)
+        {
+                helper = Vec3(1, 0, 0);
+                tangent = Vec3::cross(helper, axis);
+                len = tangent.length();
+        }
+        tangent = (len > 1e-12) ? tangent / len : Vec3(1, 0, 0);
+        bitangent = Vec3::cross(axis, tangent).normalized();
+}
+
+double wrap_angle(double angle)
+{
+        constexpr double kTwoPi = 6.28318530717958647692;
+        while (angle < 0.0)
+                angle += kTwoPi;
+        while (angle >= kTwoPi)
+                angle -= kTwoPi;
+        return angle;
+}
+
+} // namespace
+
+Cylinder::Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h,
+                                   int oid, int mid)
+        : center(c), axis(axis_.normalized()), radius(r), height(h)
+{
+        object_id = oid;
+        material_id = mid;
+        build_basis(axis, tangent, bitangent);
 }
 
 bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
-	bool hit_any = false;
-	double closest = tmax;
+        bool hit_any = false;
+        double closest = tmax;
 
-	Vec3 oc = r.orig - center;
-	double d_dot_a = Vec3::dot(r.dir, axis);
-	double oc_dot_a = Vec3::dot(oc, axis);
+        auto assign_hit = [&](double t, const Vec3 &point, const Vec3 &normal,
+                              double ratio, double u, double v)
+        {
+                rec.t = t;
+                rec.p = point;
+                rec.object_id = object_id;
+                rec.material_id = material_id;
+                rec.beam_ratio = ratio;
+                rec.u = std::clamp(u, 0.0, 1.0);
+                rec.v = std::clamp(v, 0.0, 1.0);
+                rec.set_face_normal(r, normal);
+                closest = t;
+                hit_any = true;
+        };
+
+        Vec3 oc = r.orig - center;
+        double d_dot_a = Vec3::dot(r.dir, axis);
+        double oc_dot_a = Vec3::dot(oc, axis);
 
 	Vec3 d_perp = r.dir - d_dot_a * axis;
 	Vec3 oc_perp = oc - oc_dot_a * axis;
@@ -30,77 +77,71 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	{
 		double sqrtD = std::sqrt(disc);
 		double roots[2] = {(-B - sqrtD) / (2 * A), (-B + sqrtD) / (2 * A)};
-		for (double root : roots)
-		{
-			if (root < tmin || root > closest)
-			{
-				continue;
+                for (double root : roots)
+                {
+                        if (root < tmin || root > closest)
+                        {
+                                continue;
 			}
 			double s = oc_dot_a + root * d_dot_a;
 			if (s < -height / 2 || s > height / 2)
 			{
 				continue;
-			}
-			Vec3 p = r.at(root);
-			Vec3 proj = center + axis * s;
-			Vec3 outward = (p - proj).normalized();
-			rec.t = root;
-			rec.p = p;
-			rec.object_id = object_id;
-			rec.material_id = material_id;
-			rec.beam_ratio = (s + height / 2) / height;
-			rec.set_face_normal(r, outward);
-			closest = root;
-			hit_any = true;
-		}
-	}
+                        }
+                        Vec3 p = r.at(root);
+                        Vec3 proj = center + axis * s;
+                        Vec3 outward = (p - proj).normalized();
+                        Vec3 radial = p - proj;
+                        double x = Vec3::dot(radial, tangent);
+                        double y = Vec3::dot(radial, bitangent);
+                        double angle = std::atan2(y, x);
+                        angle = wrap_angle(angle);
+                        constexpr double kTwoPi = 6.28318530717958647692;
+                        double u = angle / kTwoPi;
+                        double v = (s + height / 2.0) / height;
+                        assign_hit(root, p, outward, (s + height / 2.0) / height, u, v);
+                }
+        }
 
-	Vec3 top_center = center + axis * (height / 2);
-	Vec3 bottom_center = center - axis * (height / 2);
+        Vec3 top_center = center + axis * (height / 2);
+        Vec3 bottom_center = center - axis * (height / 2);
 
 	double denom_top = Vec3::dot(r.dir, axis);
 	if (std::fabs(denom_top) > 1e-9)
 	{
 		double t = Vec3::dot(top_center - r.orig, axis) / denom_top;
-		if (t >= tmin && t <= closest)
-		{
-			Vec3 p = r.at(t);
-			if ((p - top_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.beam_ratio = 1.0;
-				rec.set_face_normal(r, axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                if (t >= tmin && t <= closest)
+                {
+                        Vec3 p = r.at(t);
+                        if ((p - top_center).length_squared() <= radius * radius)
+                        {
+                                Vec3 diff = p - top_center;
+                                double u = Vec3::dot(diff, tangent) / (2.0 * radius) + 0.5;
+                                double v = Vec3::dot(diff, bitangent) / (2.0 * radius) + 0.5;
+                                assign_hit(t, p, axis, 1.0, u, v);
+                        }
+                }
+        }
 
-	double denom_bot = Vec3::dot(r.dir, (-1) * axis);
+        double denom_bot = Vec3::dot(r.dir, (-1) * axis);
 	if (std::fabs(denom_bot) > 1e-9)
 	{
 		double t = Vec3::dot(bottom_center - r.orig, (-1) * axis) / denom_bot;
-		if (t >= tmin && t <= closest)
-		{
-			Vec3 p = r.at(t);
-			if ((p - bottom_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.beam_ratio = 0.0;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                if (t >= tmin && t <= closest)
+                {
+                        Vec3 p = r.at(t);
+                        if ((p - bottom_center).length_squared() <= radius * radius)
+                        {
+                                Vec3 diff = p - bottom_center;
+                                double u = Vec3::dot(diff, tangent) / (2.0 * radius) + 0.5;
+                                double v = Vec3::dot(diff, bitangent) / (2.0 * radius) + 0.5;
+                                v = 1.0 - v;
+                                assign_hit(t, p, (-1) * axis, 0.0, u, v);
+                        }
+                }
+        }
 
-	return hit_any;
+        return hit_any;
 }
 
 bool Cylinder::bounding_box(AABB &out) const
@@ -116,12 +157,14 @@ bool Cylinder::bounding_box(AABB &out) const
 
 void Cylinder::rotate(const Vec3 &ax, double angle)
 {
-	auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
-	{
-		double c = std::cos(ang);
-		double s = std::sin(ang);
-		return v * c + Vec3::cross(axis, v) * s +
-			   axis * Vec3::dot(axis, v) * (1 - c);
-	};
-	axis = rotate_vec(axis, ax, angle).normalized();
+        auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
+        {
+                double c = std::cos(ang);
+                double s = std::sin(ang);
+                return v * c + Vec3::cross(axis, v) * s +
+                           axis * Vec3::dot(axis, v) * (1 - c);
+        };
+        axis = rotate_vec(axis, ax, angle).normalized();
+        tangent = rotate_vec(tangent, ax, angle).normalized();
+        bitangent = Vec3::cross(axis, tangent).normalized();
 }

--- a/src/Laser.cpp
+++ b/src/Laser.cpp
@@ -61,13 +61,15 @@ bool Laser::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		outward = outward.normalized();
 	}
 
-	rec.t = sc;
-	rec.p = pr;
-	rec.object_id = object_id;
-	rec.material_id = material_id;
-	rec.beam_ratio = (start + tc) / total_length;
-	rec.set_face_normal(r, outward);
-	return true;
+        rec.t = sc;
+        rec.p = pr;
+        rec.object_id = object_id;
+        rec.material_id = material_id;
+        rec.beam_ratio = (start + tc) / total_length;
+        rec.u = 0.0;
+        rec.v = 0.0;
+        rec.set_face_normal(r, outward);
+        return true;
 }
 
 bool Laser::bounding_box(AABB &out) const

--- a/src/Plane.cpp
+++ b/src/Plane.cpp
@@ -1,11 +1,32 @@
 #include "Plane.hpp"
 #include <cmath>
 
-Plane::Plane(const Vec3 &p, const Vec3 &n, int oid, int mid)
-	: point(p), normal(n.normalized())
+namespace
 {
-	object_id = oid;
-	material_id = mid;
+
+Vec3 orthonormal_axis(const Vec3 &normal)
+{
+        Vec3 helper = (std::fabs(normal.z) < 0.999) ? Vec3(0, 0, 1) : Vec3(0, 1, 0);
+        Vec3 u = Vec3::cross(helper, normal);
+        double len = u.length();
+        if (len <= 1e-12)
+        {
+                helper = Vec3(1, 0, 0);
+                u = Vec3::cross(helper, normal);
+                len = u.length();
+        }
+        return (len > 1e-12) ? u / len : Vec3(1, 0, 0);
+}
+
+}
+
+Plane::Plane(const Vec3 &p, const Vec3 &n, int oid, int mid)
+        : point(p), normal(n.normalized())
+{
+        object_id = oid;
+        material_id = mid;
+        u_axis = orthonormal_axis(normal);
+        v_axis = Vec3::cross(normal, u_axis).normalized();
 }
 
 bool Plane::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
@@ -19,13 +40,18 @@ bool Plane::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	if (t < tmin || t > tmax)
 	{
 		return false;
-	}
-	rec.t = t;
-	rec.p = r.at(t);
-	rec.set_face_normal(r, normal);
-	rec.material_id = material_id;
-	rec.object_id = object_id;
-	return true;
+        }
+        rec.t = t;
+        rec.p = r.at(t);
+        rec.set_face_normal(r, normal);
+        rec.material_id = material_id;
+        rec.object_id = object_id;
+        Vec3 local = rec.p - point;
+        double u = Vec3::dot(local, u_axis);
+        double v = Vec3::dot(local, v_axis);
+        rec.u = u - std::floor(u);
+        rec.v = v - std::floor(v);
+        return true;
 }
 
 bool Plane::bounding_box(AABB &out) const
@@ -42,5 +68,17 @@ void Plane::rotate(const Vec3 &axis, double angle)
 		double s = std::sin(ang);
 		return v * c + Vec3::cross(ax, v) * s + ax * Vec3::dot(ax, v) * (1 - c);
 	};
-	normal = rotate_vec(normal, axis, angle).normalized();
+        normal = rotate_vec(normal, axis, angle).normalized();
+        u_axis = rotate_vec(u_axis, axis, angle).normalized();
+        v_axis = Vec3::cross(normal, u_axis);
+        double len = v_axis.length();
+        if (len > 1e-12)
+        {
+                v_axis = v_axis / len;
+        }
+        else
+        {
+                u_axis = orthonormal_axis(normal);
+                v_axis = Vec3::cross(normal, u_axis).normalized();
+        }
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -101,7 +101,7 @@ static bool beam_light_through(const Scene &scene, const std::vector<Material> &
                 const Material &m = mats[hit_mat];
                 if (m.alpha >= 1.0)
                         return false;
-                color = mix_colors(color, m.base_color, m.alpha);
+                color = mix_colors(color, material_base_color_at(m, tmp), m.alpha);
                 intensity *= (1.0 - m.alpha);
                 shadow_ray.orig = shadow_ray.orig + shadow_ray.dir * (closest + 1e-4);
                 max_dist -= closest + 1e-4;
@@ -151,7 +151,7 @@ static bool light_through(const Scene &scene, const std::vector<Material> &mats,
                 const Material &m = mats[hit_mat];
                 if (m.alpha >= 1.0)
                         return false;
-                color = mix_colors(color, m.base_color, m.alpha);
+                color = mix_colors(color, material_base_color_at(m, tmp), m.alpha);
                 intensity *= (1.0 - m.alpha);
                 shadow_ray.orig = shadow_ray.orig + shadow_ray.dir * (closest + 1e-4);
                 max_dist -= closest + 1e-4;
@@ -212,8 +212,8 @@ Vec3 clamp_color(const Vec3 &c, double lo = 0.0, double hi = 1.0)
 Vec3 surface_color_at(const Scene &scene, const HitRecord &rec,
                                          const Material &mat)
 {
-        Vec3 base = mat.base_color;
-        Vec3 col = mat.color;
+        Vec3 base = material_base_color_at(mat, rec);
+        Vec3 col = material_color_at(mat, rec);
         if (rec.object_id >= 0 &&
                 rec.object_id < static_cast<int>(scene.objects.size()))
         {
@@ -488,8 +488,8 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
 	}
         const Material &m = mats[rec.material_id];
         Vec3 eye = (r.dir * -1.0).normalized();
-        Vec3 base = m.base_color;
-        Vec3 col = m.color;
+        Vec3 base = material_base_color_at(m, rec);
+        Vec3 col = material_color_at(m, rec);
         if (rec.object_id >= 0 &&
                 rec.object_id < static_cast<int>(scene.objects.size()))
         {
@@ -500,9 +500,9 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
                         base = col = beam->color;
                 }
         }
-	if (m.checkered)
-	{
-		Vec3 inv = Vec3(1.0, 1.0, 1.0) - base;
+        if (m.checkered)
+        {
+                Vec3 inv = Vec3(1.0, 1.0, 1.0) - base;
 		int chk = (static_cast<int>(std::floor(rec.p.x * 5)) +
 				   static_cast<int>(std::floor(rec.p.y * 5)) +
 				   static_cast<int>(std::floor(rec.p.z * 5))) &

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -149,8 +149,9 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                 if (new_len > 1e-4)
                                 {
                                         Vec3 pass_orig = forward.at(closest) + forward.dir * 1e-4;
-                                        Vec3 new_color = bm->color * (1.0 - hit_mat.alpha) +
-                                                         hit_mat.base_color * hit_mat.alpha;
+                                        Vec3 new_color =
+                                                bm->color * (1.0 - hit_mat.alpha) +
+                                                material_base_color_at(hit_mat, hit_rec) * hit_mat.alpha;
                                         double new_intens =
                                                 bm->light_intensity * (1.0 - hit_mat.alpha);
                                        auto new_bm = std::make_shared<Laser>(

--- a/src/Sphere.cpp
+++ b/src/Sphere.cpp
@@ -1,4 +1,5 @@
 #include "Sphere.hpp"
+#include <algorithm>
 #include <cmath>
 
 Sphere::Sphere(const Vec3 &c, double r, int oid, int mid) : center(c), radius(r)
@@ -29,13 +30,19 @@ bool Sphere::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 			return false;
 		}
 	}
-	rec.t = root;
-	rec.p = r.at(rec.t);
-	rec.material_id = material_id;
-	rec.object_id = object_id;
-	Vec3 outward = (rec.p - center) / radius;
-	rec.set_face_normal(r, outward);
-	return true;
+        rec.t = root;
+        rec.p = r.at(rec.t);
+        rec.material_id = material_id;
+        rec.object_id = object_id;
+        Vec3 outward = (rec.p - center) / radius;
+        constexpr double kPi = 3.14159265358979323846;
+        Vec3 unit = outward;
+        double theta = std::acos(std::clamp(-unit.y, -1.0, 1.0));
+        double phi = std::atan2(-unit.z, unit.x) + kPi;
+        rec.u = phi / (2.0 * kPi);
+        rec.v = theta / kPi;
+        rec.set_face_normal(r, outward);
+        return true;
 }
 
 bool Sphere::bounding_box(AABB &out) const

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -1,0 +1,204 @@
+#include "Texture.hpp"
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+namespace
+{
+
+double wrap_coord(double value)
+{
+        value -= std::floor(value);
+        if (value < 0.0)
+                value += 1.0;
+        return value;
+}
+
+bool parse_hex(const std::string &str, Vec3 &out)
+{
+        if (str.size() == 7 && str[0] == '#')
+        {
+                int r = std::stoi(str.substr(1, 2), nullptr, 16);
+                int g = std::stoi(str.substr(3, 2), nullptr, 16);
+                int b = std::stoi(str.substr(5, 2), nullptr, 16);
+                out = Vec3(r / 255.0, g / 255.0, b / 255.0);
+                return true;
+        }
+        if (str.size() == 4 && str[0] == '#')
+        {
+                int r = std::stoi(str.substr(1, 1), nullptr, 16);
+                int g = std::stoi(str.substr(2, 1), nullptr, 16);
+                int b = std::stoi(str.substr(3, 1), nullptr, 16);
+                out = Vec3((r * 17) / 255.0, (g * 17) / 255.0, (b * 17) / 255.0);
+                return true;
+        }
+        return false;
+}
+
+Vec3 parse_named_color(const std::string &name, bool &ok)
+{
+        static const std::unordered_map<std::string, Vec3> colors = {
+                {"black", Vec3(0.0, 0.0, 0.0)},     {"white", Vec3(1.0, 1.0, 1.0)},
+                {"red", Vec3(1.0, 0.0, 0.0)},       {"green", Vec3(0.0, 1.0, 0.0)},
+                {"blue", Vec3(0.0, 0.0, 1.0)},      {"yellow", Vec3(1.0, 1.0, 0.0)},
+                {"magenta", Vec3(1.0, 0.0, 1.0)},   {"cyan", Vec3(0.0, 1.0, 1.0)},
+                {"grey", Vec3(0.5, 0.5, 0.5)},      {"gray", Vec3(0.5, 0.5, 0.5)},
+                {"orange", Vec3(1.0, 0.5, 0.0)},    {"purple", Vec3(0.5, 0.0, 0.5)},
+        };
+        auto it = colors.find(name);
+        if (it != colors.end())
+        {
+                ok = true;
+                return it->second;
+        }
+        ok = false;
+        return Vec3(0.0, 0.0, 0.0);
+}
+
+} // namespace
+
+Vec3 Texture::sample(double u, double v) const
+{
+        if (!valid())
+                return Vec3(1.0, 1.0, 1.0);
+        double uu = wrap_coord(u);
+        double vv = wrap_coord(v);
+        int ix = static_cast<int>(std::floor(uu * width));
+        int iy = static_cast<int>(std::floor((1.0 - vv) * height));
+        if (ix < 0)
+                ix = 0;
+        if (iy < 0)
+                iy = 0;
+        if (ix >= width)
+                ix = width - 1;
+        if (iy >= height)
+                iy = height - 1;
+        return pixels[static_cast<size_t>(iy) * static_cast<size_t>(width) + static_cast<size_t>(ix)];
+}
+
+bool load_xpm_texture(const std::string &path, Texture &out, std::string &error)
+{
+        std::ifstream file(path);
+        if (!file)
+        {
+                error = "unable to open file";
+                return false;
+        }
+        std::vector<std::string> lines;
+        std::string line;
+        while (std::getline(file, line))
+        {
+                size_t first = line.find('"');
+                if (first == std::string::npos)
+                        continue;
+                size_t last = line.find_last_of('"');
+                if (last <= first)
+                        continue;
+                lines.emplace_back(line.substr(first + 1, last - first - 1));
+        }
+        if (lines.empty())
+        {
+                error = "missing XPM header";
+                return false;
+        }
+        std::istringstream header(lines[0]);
+        int width = 0;
+        int height = 0;
+        int colors = 0;
+        int cpp = 0;
+        if (!(header >> width >> height >> colors >> cpp))
+        {
+                error = "invalid XPM header";
+                return false;
+        }
+        if (width <= 0 || height <= 0 || colors <= 0 || cpp <= 0)
+        {
+                error = "XPM header values out of range";
+                return false;
+        }
+        if (static_cast<int>(lines.size()) < 1 + colors + height)
+        {
+                error = "XPM data truncated";
+                return false;
+        }
+        std::unordered_map<std::string, Vec3> palette;
+        palette.reserve(static_cast<size_t>(colors));
+        for (int i = 0; i < colors; ++i)
+        {
+                const std::string &entry = lines[1 + i];
+                if (static_cast<int>(entry.size()) < cpp)
+                {
+                        error = "invalid color entry";
+                        return false;
+                }
+                std::string key = entry.substr(0, cpp);
+                std::string rest = entry.substr(cpp);
+                std::istringstream iss(rest);
+                std::string token;
+                Vec3 value(0.0, 0.0, 0.0);
+                bool have_color = false;
+                while (iss >> token)
+                {
+                        if (token == "c" || token == "C")
+                        {
+                                if (!(iss >> token))
+                                        break;
+                                std::string lower;
+                                lower.reserve(token.size());
+                                for (char ch : token)
+                                        lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
+                                if (lower == "none")
+                                {
+                                        value = Vec3(0.0, 0.0, 0.0);
+                                        have_color = true;
+                                }
+                                else if (parse_hex(token, value))
+                                {
+                                        have_color = true;
+                                }
+                                else
+                                {
+                                        bool ok = false;
+                                        value = parse_named_color(lower, ok);
+                                        have_color = ok;
+                                }
+                                break;
+                        }
+                }
+                if (!have_color)
+                {
+                        error = "unsupported color specification";
+                        return false;
+                }
+                palette[key] = value;
+        }
+        out.width = width;
+        out.height = height;
+        out.pixels.assign(static_cast<size_t>(width * height), Vec3(0.0, 0.0, 0.0));
+        for (int y = 0; y < height; ++y)
+        {
+                const std::string &row = lines[1 + colors + y];
+                if (static_cast<int>(row.size()) < cpp * width)
+                {
+                        error = "invalid pixel row";
+                        return false;
+                }
+                for (int x = 0; x < width; ++x)
+                {
+                        std::string code = row.substr(x * cpp, cpp);
+                        auto it = palette.find(code);
+                        if (it == palette.end())
+                        {
+                                error = "undefined color code";
+                                return false;
+                        }
+                        out.pixels[static_cast<size_t>(y) * static_cast<size_t>(width) + static_cast<size_t>(x)] = it->second;
+                }
+        }
+        error.clear();
+        return true;
+}

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1,10 +1,24 @@
 #include "material.hpp"
+#include "Texture.hpp"
+#include "Hittable.hpp"
 #include <algorithm>
 #include <cmath>
 
+namespace
+{
+
+Vec3 sample_texture(const Material &m, const HitRecord &rec)
+{
+        if (!m.texture)
+                return Vec3(1.0, 1.0, 1.0);
+        return m.texture->sample(rec.u, rec.v);
+}
+
+} // namespace
+
 Vec3 phong(const Material &m, const Ambient &ambient,
-		   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,
-		   const Vec3 &eye)
+                   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,
+                   const Vec3 &eye)
 {
 	Vec3 base = m.base_color;
 	Vec3 col = m.color;
@@ -84,4 +98,17 @@ Vec3 phong(const Material &m, const Ambient &ambient,
                                           L.color.z * spec * atten);
         }
 	return c;
+}
+
+Vec3 material_color_at(const Material &m, const HitRecord &rec)
+{
+        Vec3 tex = sample_texture(m, rec);
+        return Vec3(m.color.x * tex.x, m.color.y * tex.y, m.color.z * tex.z);
+}
+
+Vec3 material_base_color_at(const Material &m, const HitRecord &rec)
+{
+        Vec3 tex = sample_texture(m, rec);
+        return Vec3(m.base_color.x * tex.x, m.base_color.y * tex.y,
+                                m.base_color.z * tex.z);
 }


### PR DESCRIPTION
## Summary
- add a texture abstraction with an XPM loader and cache it from the parser when scenes specify an optional `texture` path
- extend materials and rendering so textured surfaces sample colors via new UV coordinates
- compute UV coordinates for planes, spheres, cubes, cylinders, and cones so textures map correctly

## Testing
- cmake -S . -B build *(fails: SDL2 package configuration files not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5d1c6bd4832f9f9eafa4e8b9c4e0