### PR TITLE
Add texture support for scene objects

### DIFF
--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -25,12 +25,15 @@ class HitRecord
 	public:
 	Vec3 p;
 	Vec3 normal;
-	double t;
-	int object_id;
-	int material_id;
-	bool front_face;
-	double beam_ratio = 0.0;
-	void set_face_normal(const Ray &r, const Vec3 &outward_normal);
+        double t;
+        int object_id;
+        int material_id;
+        bool front_face;
+        double beam_ratio = 0.0;
+        double u = 0.0;
+        double v = 0.0;
+        bool has_uv = false;
+        void set_face_normal(const Ray &r, const Vec3 &outward_normal);
 };
 
 class Hittable

--- a/inc/material.hpp
+++ b/inc/material.hpp
@@ -2,6 +2,7 @@
 #pragma once
 #include "Vec3.hpp"
 #include "light.hpp"
+#include <string>
 #include <vector>
 
 #define REFLECTION 50
@@ -17,6 +18,13 @@ class Material
 	bool mirror = false;
 	bool random_alpha = false;
 	bool checkered = false; // render as checkered pattern when true
+	int texture_width = 0;
+	int texture_height = 0;
+	std::vector<Vec3> texture_data;
+	std::string texture_path;
+
+	bool has_texture() const;
+	Vec3 sample_texture(double u, double v) const;
 };
 
 Vec3 phong(const Material &m, const Ambient &ambient,

--- a/src/Cube.cpp
+++ b/src/Cube.cpp
@@ -56,10 +56,54 @@ bool Cube::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	rec.material_id = material_id;
 	rec.object_id = object_id;
 
-	Vec3 normal_world = normal_local.x * axis[0] + normal_local.y * axis[1] +
-						normal_local.z * axis[2];
-	rec.set_face_normal(r, normal_world);
-	return true;
+        Vec3 normal_world = normal_local.x * axis[0] + normal_local.y * axis[1] +
+                                                normal_local.z * axis[2];
+        rec.set_face_normal(r, normal_world);
+        Vec3 local = rec.p - center;
+        double lx = Vec3::dot(local, axis[0]);
+        double ly = Vec3::dot(local, axis[1]);
+        double lz = Vec3::dot(local, axis[2]);
+        double u = 0.5;
+        double v = 0.5;
+        if (std::fabs(normal_local.x) > 0.5)
+        {
+                double denom_u = half.y * 2.0;
+                double denom_v = half.z * 2.0;
+                if (denom_u > 1e-8)
+                        u = (ly + half.y) / denom_u;
+                if (denom_v > 1e-8)
+                        v = (lz + half.z) / denom_v;
+                if (normal_local.x < 0.0)
+                        u = 1.0 - u;
+        }
+        else if (std::fabs(normal_local.y) > 0.5)
+        {
+                double denom_u = half.x * 2.0;
+                double denom_v = half.z * 2.0;
+                if (denom_u > 1e-8)
+                        u = (lx + half.x) / denom_u;
+                if (denom_v > 1e-8)
+                        v = (lz + half.z) / denom_v;
+                if (normal_local.y > 0.0)
+                        u = 1.0 - u;
+        }
+        else
+        {
+                double denom_u = half.x * 2.0;
+                double denom_v = half.y * 2.0;
+                if (denom_u > 1e-8)
+                        u = (lx + half.x) / denom_u;
+                if (denom_v > 1e-8)
+                        v = (ly + half.y) / denom_v;
+                if (normal_local.z > 0.0)
+                        u = 1.0 - u;
+        }
+        u = std::clamp(u, 0.0, 1.0);
+        v = std::clamp(v, 0.0, 1.0);
+        rec.u = u;
+        rec.v = v;
+        rec.has_uv = true;
+        return true;
 }
 
 bool Cube::bounding_box(AABB &out) const

--- a/src/Cylinder.cpp
+++ b/src/Cylinder.cpp
@@ -1,5 +1,42 @@
 #include "Cylinder.hpp"
+#include <algorithm>
 #include <cmath>
+
+namespace
+{
+struct OrthonormalBasis
+{
+        Vec3 u;
+        Vec3 v;
+        Vec3 w;
+};
+
+OrthonormalBasis make_basis(const Vec3 &axis)
+{
+        OrthonormalBasis basis{};
+        double len2 = axis.length_squared();
+        if (len2 <= 1e-12)
+        {
+                basis.w = Vec3(0, 0, 1);
+                basis.u = Vec3(1, 0, 0);
+                basis.v = Vec3(0, 1, 0);
+                return basis;
+        }
+        basis.w = axis / std::sqrt(len2);
+        Vec3 helper = (std::fabs(basis.w.z) < 0.999) ? Vec3(0, 0, 1) : Vec3(0, 1, 0);
+        Vec3 u = Vec3::cross(helper, basis.w);
+        double ulen = u.length();
+        if (ulen <= 1e-12)
+        {
+                helper = Vec3(0, 1, 0);
+                u = Vec3::cross(helper, basis.w);
+                ulen = u.length();
+        }
+        basis.u = (ulen > 1e-12) ? u / ulen : Vec3(1, 0, 0);
+        basis.v = Vec3::cross(basis.w, basis.u);
+        return basis;
+}
+} // namespace
 
 Cylinder::Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h,
 				   int oid, int mid)
@@ -11,8 +48,9 @@ Cylinder::Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h,
 
 bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
-	bool hit_any = false;
-	double closest = tmax;
+        bool hit_any = false;
+        double closest = tmax;
+        OrthonormalBasis basis = make_basis(axis);
 
 	Vec3 oc = r.orig - center;
 	double d_dot_a = Vec3::dot(r.dir, axis);
@@ -48,12 +86,22 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 			rec.p = p;
 			rec.object_id = object_id;
 			rec.material_id = material_id;
-			rec.beam_ratio = (s + height / 2) / height;
-			rec.set_face_normal(r, outward);
-			closest = root;
-			hit_any = true;
-		}
-	}
+                        rec.beam_ratio = (s + height / 2) / height;
+                        rec.set_face_normal(r, outward);
+                        double angle = std::atan2(Vec3::dot(outward, basis.v), Vec3::dot(outward, basis.u));
+                        double tex_u = 1.0 - (angle + M_PI) / (2.0 * M_PI);
+                        tex_u -= std::floor(tex_u);
+                        if (tex_u < 0.0)
+                                tex_u += 1.0;
+                        double tex_v = (s + height / 2.0) / height;
+                        tex_v = std::clamp(tex_v, 0.0, 1.0);
+                        rec.u = tex_u;
+                        rec.v = tex_v;
+                        rec.has_uv = true;
+                        closest = root;
+                        hit_any = true;
+                }
+        }
 
 	Vec3 top_center = center + axis * (height / 2);
 	Vec3 bottom_center = center - axis * (height / 2);
@@ -65,19 +113,31 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		if (t >= tmin && t <= closest)
 		{
 			Vec3 p = r.at(t);
-			if ((p - top_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.beam_ratio = 1.0;
-				rec.set_face_normal(r, axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                        if ((p - top_center).length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.beam_ratio = 1.0;
+                                rec.set_face_normal(r, axis);
+                                double tex_u = 0.5;
+                                double tex_v = 0.5;
+                                if (radius > 1e-8)
+                                {
+                                        tex_u = 0.5 + Vec3::dot(p - top_center, basis.u) / (2.0 * radius);
+                                        tex_v = 0.5 + Vec3::dot(p - top_center, basis.v) / (2.0 * radius);
+                                }
+                                tex_u = std::clamp(tex_u, 0.0, 1.0);
+                                tex_v = std::clamp(tex_v, 0.0, 1.0);
+                                rec.u = tex_u;
+                                rec.v = tex_v;
+                                rec.has_uv = true;
+                                closest = t;
+                                hit_any = true;
+                        }
+                }
+        }
 
 	double denom_bot = Vec3::dot(r.dir, (-1) * axis);
 	if (std::fabs(denom_bot) > 1e-9)
@@ -86,17 +146,29 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		if (t >= tmin && t <= closest)
 		{
 			Vec3 p = r.at(t);
-			if ((p - bottom_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.beam_ratio = 0.0;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
+                        if ((p - bottom_center).length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.beam_ratio = 0.0;
+                                rec.set_face_normal(r, (-1) * axis);
+                                double tex_u = 0.5;
+                                double tex_v = 0.5;
+                                if (radius > 1e-8)
+                                {
+                                        tex_u = 0.5 + Vec3::dot(p - bottom_center, basis.u) / (2.0 * radius);
+                                        tex_v = 0.5 + Vec3::dot(p - bottom_center, basis.v) / (2.0 * radius);
+                                }
+                                tex_u = std::clamp(tex_u, 0.0, 1.0);
+                                tex_v = std::clamp(1.0 - tex_v, 0.0, 1.0);
+                                rec.u = tex_u;
+                                rec.v = tex_v;
+                                rec.has_uv = true;
+                                closest = t;
+                                hit_any = true;
+                        }
 		}
 	}
 

--- a/src/MapSaver.cpp
+++ b/src/MapSaver.cpp
@@ -200,7 +200,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(false) << "\n";
                 out << "movable = " << bool_str(rec.plane->movable) << "\n";
                 out << "scorable = " << bool_str(rec.plane->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cube_index = 1;
@@ -218,7 +221,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cube)) << "\n";
                 out << "movable = " << bool_str(rec.cube->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cube->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int sphere_index = 1;
@@ -234,7 +240,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.sphere)) << "\n";
                 out << "movable = " << bool_str(rec.sphere->movable) << "\n";
                 out << "scorable = " << bool_str(rec.sphere->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cone_index = 1;
@@ -251,7 +260,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cone)) << "\n";
                 out << "movable = " << bool_str(rec.cone->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cone->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cylinder_index = 1;
@@ -268,7 +280,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cylinder)) << "\n";
                 out << "movable = " << bool_str(rec.cylinder->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cylinder->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int beam_source_index = 1;

--- a/src/Plane.cpp
+++ b/src/Plane.cpp
@@ -20,12 +20,36 @@ bool Plane::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	{
 		return false;
 	}
-	rec.t = t;
-	rec.p = r.at(t);
-	rec.set_face_normal(r, normal);
-	rec.material_id = material_id;
-	rec.object_id = object_id;
-	return true;
+        rec.t = t;
+        rec.p = r.at(t);
+        rec.set_face_normal(r, normal);
+        rec.material_id = material_id;
+        rec.object_id = object_id;
+        Vec3 tangent = Vec3::cross((std::fabs(normal.y) < 0.999) ? Vec3(0, 1, 0) : Vec3(1, 0, 0), normal);
+        double tangent_len = tangent.length();
+        if (tangent_len <= 1e-8)
+                tangent = Vec3(1, 0, 0);
+        else
+                tangent = tangent / tangent_len;
+        Vec3 bitangent = Vec3::cross(normal, tangent);
+        double bitangent_len = bitangent.length();
+        if (bitangent_len <= 1e-8)
+                bitangent = Vec3(0, 0, 1);
+        else
+                bitangent = bitangent / bitangent_len;
+        Vec3 rel = rec.p - point;
+        double u = Vec3::dot(rel, tangent);
+        double v = Vec3::dot(rel, bitangent);
+        u -= std::floor(u);
+        v -= std::floor(v);
+        if (u < 0.0)
+                u += 1.0;
+        if (v < 0.0)
+                v += 1.0;
+        rec.u = u;
+        rec.v = v;
+        rec.has_uv = true;
+        return true;
 }
 
 bool Plane::bounding_box(AABB &out) const

--- a/src/Sphere.cpp
+++ b/src/Sphere.cpp
@@ -1,4 +1,5 @@
 #include "Sphere.hpp"
+#include <algorithm>
 #include <cmath>
 
 Sphere::Sphere(const Vec3 &c, double r, int oid, int mid) : center(c), radius(r)
@@ -34,8 +35,13 @@ bool Sphere::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	rec.material_id = material_id;
 	rec.object_id = object_id;
 	Vec3 outward = (rec.p - center) / radius;
-	rec.set_face_normal(r, outward);
-	return true;
+        rec.set_face_normal(r, outward);
+        double theta = std::acos(std::clamp(outward.y, -1.0, 1.0));
+        double phi = std::atan2(outward.z, outward.x);
+        rec.u = 1.0 - (phi + M_PI) / (2.0 * M_PI);
+        rec.v = theta / M_PI;
+        rec.has_uv = true;
+        return true;
 }
 
 bool Sphere::bounding_box(AABB &out) const

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -2,9 +2,45 @@
 #include <algorithm>
 #include <cmath>
 
+bool Material::has_texture() const
+{
+        return texture_width > 0 && texture_height > 0 &&
+               texture_data.size() == static_cast<size_t>(texture_width * texture_height);
+}
+
+Vec3 Material::sample_texture(double u, double v) const
+{
+        if (!has_texture())
+                return base_color;
+
+        double u_wrapped = std::fmod(u, 1.0);
+        if (u_wrapped < 0.0)
+                u_wrapped += 1.0;
+        double v_wrapped = std::fmod(v, 1.0);
+        if (v_wrapped < 0.0)
+                v_wrapped += 1.0;
+
+        int ix = static_cast<int>(std::floor(u_wrapped * texture_width));
+        int iy = static_cast<int>(std::floor((1.0 - v_wrapped) * texture_height));
+        if (ix < 0)
+                ix = 0;
+        if (iy < 0)
+                iy = 0;
+        if (ix >= texture_width)
+                ix = texture_width - 1;
+        if (iy >= texture_height)
+                iy = texture_height - 1;
+
+        size_t index = static_cast<size_t>(iy) * static_cast<size_t>(texture_width) +
+                       static_cast<size_t>(ix);
+        if (index >= texture_data.size())
+                return base_color;
+        return texture_data[index];
+}
+
 Vec3 phong(const Material &m, const Ambient &ambient,
-		   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,
-		   const Vec3 &eye)
+                   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,
+                   const Vec3 &eye)
 {
 	Vec3 base = m.base_color;
 	Vec3 col = m.color;


### PR DESCRIPTION
## Summary
- add texture metadata to materials and implement XPM loading in the parser so scene objects can reference textures
- compute UV coordinates for standard primitives and sample textures during shading
- persist texture assignments when saving scenes

## Testing
- cmake -S . -B build *(fails: missing SDL2 package)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5d1c6bd4832f9f9eafa4e8b9c4e0