### PR TITLE
Make beam targets block lasers and spotlight when hit

### DIFF
--- a/inc/BeamTarget.hpp
+++ b/inc/BeamTarget.hpp
@@ -15,7 +15,7 @@ public:
     bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }
     void translate(const Vec3 &delta) override;
     bool blocks_when_transparent() const override { return true; }
-    bool casts_shadow() const override { return false; }
+    bool casts_shadow() const override { return goal_active; }
     ShapeType shape_type() const override { return ShapeType::BeamTarget; }
     void start_goal();
     void update_goal(double dt, std::vector<Material> &mats);


### PR DESCRIPTION
## Summary
- allow beam targets to cast shadows while their hit animation is active so they can occlude beam lighting
- update beam processing to mark targets on hit, prevent transparent pass-through, and keep spawned spotlights from ignoring the impacted target

## Testing
- cmake -S . -B build *(fails: missing SDL2 configuration files in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5ed5c500832f99e81f0fa9fad622