### PR TITLE
Implement texture mapping support

### DIFF
--- a/inc/Cone.hpp
+++ b/inc/Cone.hpp
@@ -5,16 +5,20 @@
 class Cone : public Hittable
 {
 	public:
-	Vec3 center;
-	Vec3 axis;
-	double radius;
-	double height;
-	Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid);
+        Vec3 center;
+        Vec3 axis;
+        double radius;
+        double height;
+        Vec3 axis_u;
+        Vec3 axis_v;
+        Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid);
 
-	bool hit(const Ray &r, double tmin, double tmax,
-			 HitRecord &rec) const override;
-	bool bounding_box(AABB &out) const override;
-	void translate(const Vec3 &delta) override { center += delta; }
-	void rotate(const Vec3 &axis, double angle) override;
-	ShapeType shape_type() const override { return ShapeType::Cone; }
+        bool hit(const Ray &r, double tmin, double tmax,
+                         HitRecord &rec) const override;
+        bool bounding_box(AABB &out) const override;
+        void translate(const Vec3 &delta) override { center += delta; }
+        void rotate(const Vec3 &axis, double angle) override;
+        ShapeType shape_type() const override { return ShapeType::Cone; }
+        private:
+        void update_basis();
 };

--- a/inc/Cylinder.hpp
+++ b/inc/Cylinder.hpp
@@ -5,17 +5,21 @@
 class Cylinder : public Hittable
 {
 	public:
-	Vec3 center;
-	Vec3 axis;
-	double radius;
-	double height;
-	Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h, int oid,
-			 int mid);
+        Vec3 center;
+        Vec3 axis;
+        double radius;
+        double height;
+        Vec3 axis_u;
+        Vec3 axis_v;
+        Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h, int oid,
+                         int mid);
 
-	bool hit(const Ray &r, double tmin, double tmax,
-			 HitRecord &rec) const override;
-	bool bounding_box(AABB &out) const override;
-	void translate(const Vec3 &delta) override { center += delta; }
-	void rotate(const Vec3 &axis, double angle) override;
-	ShapeType shape_type() const override { return ShapeType::Cylinder; }
+        bool hit(const Ray &r, double tmin, double tmax,
+                         HitRecord &rec) const override;
+        bool bounding_box(AABB &out) const override;
+        void translate(const Vec3 &delta) override { center += delta; }
+        void rotate(const Vec3 &axis, double angle) override;
+        ShapeType shape_type() const override { return ShapeType::Cylinder; }
+        private:
+        void update_basis();
 };

--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -22,15 +22,17 @@ class Material;
 
 class HitRecord
 {
-	public:
-	Vec3 p;
-	Vec3 normal;
-	double t;
-	int object_id;
-	int material_id;
-	bool front_face;
-	double beam_ratio = 0.0;
-	void set_face_normal(const Ray &r, const Vec3 &outward_normal);
+        public:
+        Vec3 p;
+        Vec3 normal;
+        double t;
+        int object_id;
+        int material_id;
+        bool front_face;
+        double beam_ratio = 0.0;
+        double u = 0.0;
+        double v = 0.0;
+        void set_face_normal(const Ray &r, const Vec3 &outward_normal);
 };
 
 class Hittable

--- a/inc/Plane.hpp
+++ b/inc/Plane.hpp
@@ -4,16 +4,20 @@
 
 class Plane : public Hittable
 {
-	public:
-	Vec3 point;
-	Vec3 normal;
-	Plane(const Vec3 &p, const Vec3 &n, int oid, int mid);
+        public:
+        Vec3 point;
+        Vec3 normal;
+        Plane(const Vec3 &p, const Vec3 &n, int oid, int mid);
 
-	bool hit(const Ray &r, double tmin, double tmax,
-			 HitRecord &rec) const override;
-	bool bounding_box(AABB &out) const override;
-	bool is_plane() const override { return true; }
-	void translate(const Vec3 &delta) override { point += delta; }
-	void rotate(const Vec3 &axis, double angle) override;
-	ShapeType shape_type() const override { return ShapeType::Plane; }
+        bool hit(const Ray &r, double tmin, double tmax,
+                         HitRecord &rec) const override;
+        bool bounding_box(AABB &out) const override;
+        bool is_plane() const override { return true; }
+        void translate(const Vec3 &delta) override { point += delta; }
+        void rotate(const Vec3 &axis, double angle) override;
+        ShapeType shape_type() const override { return ShapeType::Plane; }
+        private:
+        Vec3 tangent_u;
+        Vec3 tangent_v;
+        void update_basis();
 };

--- a/inc/Texture.hpp
+++ b/inc/Texture.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "Vec3.hpp"
+#include <memory>
+#include <string>
+#include <vector>
+
+class Texture
+{
+        public:
+        Texture() = default;
+
+        Vec3 sample(double u, double v) const;
+        int width() const { return width_; }
+        int height() const { return height_; }
+        bool empty() const { return width_ <= 0 || height_ <= 0 || pixels_.empty(); }
+
+        private:
+        int width_ = 0;
+        int height_ = 0;
+        std::vector<Vec3> pixels_;
+
+        Vec3 texel(int x, int y) const;
+
+        friend std::shared_ptr<Texture> load_texture(const std::string &path,
+                                                     std::string &error);
+};
+
+std::shared_ptr<Texture> load_texture(const std::string &path, std::string &error);

--- a/inc/material.hpp
+++ b/inc/material.hpp
@@ -2,9 +2,15 @@
 #pragma once
 #include "Vec3.hpp"
 #include "light.hpp"
+#include <memory>
+#include <string>
 #include <vector>
 
 #define REFLECTION 50
+
+class Texture;
+class Scene;
+class HitRecord;
 
 class Material
 {
@@ -16,7 +22,13 @@ class Material
 	double specular_k = 0.5;
 	bool mirror = false;
 	bool random_alpha = false;
-	bool checkered = false; // render as checkered pattern when true
+        bool checkered = false; // render as checkered pattern when true
+        std::shared_ptr<Texture> texture;
+        std::string texture_path;
+
+        bool has_texture() const { return static_cast<bool>(texture); }
+        Vec3 sample_texture(double u, double v) const;
+        Vec3 surface_color(const Scene &scene, const HitRecord &rec) const;
 };
 
 Vec3 phong(const Material &m, const Ambient &ambient,

--- a/src/Cone.cpp
+++ b/src/Cone.cpp
@@ -1,17 +1,34 @@
 #include "Cone.hpp"
+#include <algorithm>
 #include <cmath>
 
-Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid)
-	: center(c), axis(ax.normalized()), radius(r), height(h)
+namespace
 {
-	object_id = oid;
-	material_id = mid;
+const double kPi = 3.14159265358979323846;
+}
+
+Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid)
+        : center(c), axis(ax.normalized()), radius(r), height(h)
+{
+        object_id = oid;
+        material_id = mid;
+        update_basis();
+}
+
+void Cone::update_basis()
+{
+        Vec3 helper = (std::fabs(axis.y) < 0.999) ? Vec3(0, 1, 0) : Vec3(1, 0, 0);
+        axis_u = Vec3::cross(axis, helper);
+        if (axis_u.length_squared() <= 1e-12)
+                axis_u = Vec3::cross(axis, Vec3(0, 0, 1));
+        axis_u = axis_u.normalized();
+        axis_v = Vec3::cross(axis, axis_u).normalized();
 }
 
 bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
-	bool hit_any = false;
-	double closest = tmax;
+        bool hit_any = false;
+        double closest = tmax;
 
 	Vec3 apex = center + axis * (height * 0.5);
 	Vec3 down = (-1) * axis;
@@ -47,17 +64,28 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 			Vec3 p = r.at(root);
 			double ax_dist = y;
 			Vec3 x_parallel = down * ax_dist;
-			Vec3 x_perp = (oc + root * r.dir) - x_parallel;
-			Vec3 normal = (x_perp - (k * k * ax_dist) * down).normalized();
-			rec.t = root;
-			rec.p = p;
-			rec.object_id = object_id;
-			rec.material_id = material_id;
-			rec.set_face_normal(r, normal);
-			closest = root;
-			hit_any = true;
-		}
-	}
+                        Vec3 x_perp = (oc + root * r.dir) - x_parallel;
+                        Vec3 normal = (x_perp - (k * k * ax_dist) * down).normalized();
+                        rec.t = root;
+                        rec.p = p;
+                        rec.object_id = object_id;
+                        rec.material_id = material_id;
+                        rec.set_face_normal(r, normal);
+                        Vec3 diff = p - apex;
+                        double axial = std::clamp(ax_dist, 0.0, height);
+                        Vec3 radial = diff - down * axial;
+                        double angle = std::atan2(Vec3::dot(radial, axis_v),
+                                                  Vec3::dot(radial, axis_u));
+                        double u = (angle + kPi) / (2.0 * kPi);
+                        if (u < 0.0)
+                                u += 1.0;
+                        double v = axial / height;
+                        rec.u = std::clamp(u, 0.0, 1.0);
+                        rec.v = std::clamp(v, 0.0, 1.0);
+                        closest = root;
+                        hit_any = true;
+                }
+        }
 
 	Vec3 base_center = center - axis * (height * 0.5);
 	double denom = Vec3::dot(r.dir, (-1) * axis);
@@ -66,19 +94,24 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		double t = Vec3::dot(base_center - r.orig, (-1) * axis) / denom;
 		if (t >= tmin && t <= closest)
 		{
-			Vec3 p = r.at(t);
-			if ((p - base_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                        Vec3 p = r.at(t);
+                        if ((p - base_center).length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.set_face_normal(r, (-1) * axis);
+                                Vec3 diff = p - base_center;
+                                double u = 0.5 + Vec3::dot(diff, axis_u) / (2.0 * radius);
+                                double v = 0.5 - Vec3::dot(diff, axis_v) / (2.0 * radius);
+                                rec.u = std::clamp(u, 0.0, 1.0);
+                                rec.v = std::clamp(1.0 - v, 0.0, 1.0);
+                                closest = t;
+                                hit_any = true;
+                        }
+                }
+        }
 
 	return hit_any;
 }
@@ -96,12 +129,13 @@ bool Cone::bounding_box(AABB &out) const
 
 void Cone::rotate(const Vec3 &ax, double angle)
 {
-	auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
-	{
-		double c = std::cos(ang);
-		double s = std::sin(ang);
-		return v * c + Vec3::cross(axis, v) * s +
-			   axis * Vec3::dot(axis, v) * (1 - c);
-	};
-	axis = rotate_vec(axis, ax, angle).normalized();
+        auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
+        {
+                double c = std::cos(ang);
+                double s = std::sin(ang);
+                return v * c + Vec3::cross(axis, v) * s +
+                           axis * Vec3::dot(axis, v) * (1 - c);
+        };
+        axis = rotate_vec(axis, ax, angle).normalized();
+        update_basis();
 }

--- a/src/Cylinder.cpp
+++ b/src/Cylinder.cpp
@@ -1,18 +1,35 @@
 #include "Cylinder.hpp"
+#include <algorithm>
 #include <cmath>
 
-Cylinder::Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h,
-				   int oid, int mid)
-	: center(c), axis(axis_.normalized()), radius(r), height(h)
+namespace
 {
-	object_id = oid;
-	material_id = mid;
+const double kPi = 3.14159265358979323846;
+}
+
+Cylinder::Cylinder(const Vec3 &c, const Vec3 &axis_, double r, double h,
+                                   int oid, int mid)
+        : center(c), axis(axis_.normalized()), radius(r), height(h)
+{
+        object_id = oid;
+        material_id = mid;
+        update_basis();
+}
+
+void Cylinder::update_basis()
+{
+        Vec3 helper = (std::fabs(axis.y) < 0.999) ? Vec3(0, 1, 0) : Vec3(1, 0, 0);
+        axis_u = Vec3::cross(axis, helper);
+        if (axis_u.length_squared() <= 1e-12)
+                axis_u = Vec3::cross(axis, Vec3(0, 0, 1));
+        axis_u = axis_u.normalized();
+        axis_v = Vec3::cross(axis, axis_u).normalized();
 }
 
 bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
-	bool hit_any = false;
-	double closest = tmax;
+        bool hit_any = false;
+        double closest = tmax;
 
 	Vec3 oc = r.orig - center;
 	double d_dot_a = Vec3::dot(r.dir, axis);
@@ -41,19 +58,28 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 			{
 				continue;
 			}
-			Vec3 p = r.at(root);
-			Vec3 proj = center + axis * s;
-			Vec3 outward = (p - proj).normalized();
-			rec.t = root;
-			rec.p = p;
-			rec.object_id = object_id;
-			rec.material_id = material_id;
-			rec.beam_ratio = (s + height / 2) / height;
-			rec.set_face_normal(r, outward);
-			closest = root;
-			hit_any = true;
-		}
-	}
+                        Vec3 p = r.at(root);
+                        Vec3 proj = center + axis * s;
+                        Vec3 outward = (p - proj).normalized();
+                        rec.t = root;
+                        rec.p = p;
+                        rec.object_id = object_id;
+                        rec.material_id = material_id;
+                        rec.beam_ratio = (s + height / 2) / height;
+                        rec.set_face_normal(r, outward);
+                        Vec3 radial = (p - center) - axis * s;
+                        double angle = std::atan2(Vec3::dot(radial, axis_v),
+                                                  Vec3::dot(radial, axis_u));
+                        double u = (angle + kPi) / (2.0 * kPi);
+                        if (u < 0.0)
+                                u += 1.0;
+                        double v = 1.0 - ((s + height / 2.0) / height);
+                        rec.u = std::clamp(u, 0.0, 1.0);
+                        rec.v = std::clamp(v, 0.0, 1.0);
+                        closest = root;
+                        hit_any = true;
+                }
+        }
 
 	Vec3 top_center = center + axis * (height / 2);
 	Vec3 bottom_center = center - axis * (height / 2);
@@ -64,20 +90,25 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		double t = Vec3::dot(top_center - r.orig, axis) / denom_top;
 		if (t >= tmin && t <= closest)
 		{
-			Vec3 p = r.at(t);
-			if ((p - top_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.beam_ratio = 1.0;
-				rec.set_face_normal(r, axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                        Vec3 p = r.at(t);
+                        if ((p - top_center).length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.beam_ratio = 1.0;
+                                rec.set_face_normal(r, axis);
+                                Vec3 diff = p - top_center;
+                                double u = 0.5 + Vec3::dot(diff, axis_u) / (2.0 * radius);
+                                double v = 0.5 - Vec3::dot(diff, axis_v) / (2.0 * radius);
+                                rec.u = std::clamp(u, 0.0, 1.0);
+                                rec.v = std::clamp(v, 0.0, 1.0);
+                                closest = t;
+                                hit_any = true;
+                        }
+                }
+        }
 
 	double denom_bot = Vec3::dot(r.dir, (-1) * axis);
 	if (std::fabs(denom_bot) > 1e-9)
@@ -85,20 +116,25 @@ bool Cylinder::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		double t = Vec3::dot(bottom_center - r.orig, (-1) * axis) / denom_bot;
 		if (t >= tmin && t <= closest)
 		{
-			Vec3 p = r.at(t);
-			if ((p - bottom_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.beam_ratio = 0.0;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                        Vec3 p = r.at(t);
+                        if ((p - bottom_center).length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.beam_ratio = 0.0;
+                                rec.set_face_normal(r, (-1) * axis);
+                                Vec3 diff = p - bottom_center;
+                                double u = 0.5 + Vec3::dot(diff, axis_u) / (2.0 * radius);
+                                double v = 0.5 - Vec3::dot(diff, axis_v) / (2.0 * radius);
+                                rec.u = std::clamp(u, 0.0, 1.0);
+                                rec.v = std::clamp(1.0 - v, 0.0, 1.0);
+                                closest = t;
+                                hit_any = true;
+                        }
+                }
+        }
 
 	return hit_any;
 }
@@ -116,12 +152,13 @@ bool Cylinder::bounding_box(AABB &out) const
 
 void Cylinder::rotate(const Vec3 &ax, double angle)
 {
-	auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
-	{
-		double c = std::cos(ang);
-		double s = std::sin(ang);
-		return v * c + Vec3::cross(axis, v) * s +
-			   axis * Vec3::dot(axis, v) * (1 - c);
-	};
-	axis = rotate_vec(axis, ax, angle).normalized();
+        auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
+        {
+                double c = std::cos(ang);
+                double s = std::sin(ang);
+                return v * c + Vec3::cross(axis, v) * s +
+                           axis * Vec3::dot(axis, v) * (1 - c);
+        };
+        axis = rotate_vec(axis, ax, angle).normalized();
+        update_basis();
 }

--- a/src/Laser.cpp
+++ b/src/Laser.cpp
@@ -63,11 +63,13 @@ bool Laser::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 
 	rec.t = sc;
 	rec.p = pr;
-	rec.object_id = object_id;
-	rec.material_id = material_id;
-	rec.beam_ratio = (start + tc) / total_length;
-	rec.set_face_normal(r, outward);
-	return true;
+        rec.object_id = object_id;
+        rec.material_id = material_id;
+        rec.beam_ratio = (start + tc) / total_length;
+        rec.set_face_normal(r, outward);
+        rec.u = 0.0;
+        rec.v = 0.0;
+        return true;
 }
 
 bool Laser::bounding_box(AABB &out) const

--- a/src/MapSaver.cpp
+++ b/src/MapSaver.cpp
@@ -200,7 +200,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(false) << "\n";
                 out << "movable = " << bool_str(rec.plane->movable) << "\n";
                 out << "scorable = " << bool_str(rec.plane->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cube_index = 1;
@@ -218,7 +221,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cube)) << "\n";
                 out << "movable = " << bool_str(rec.cube->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cube->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int sphere_index = 1;
@@ -234,7 +240,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.sphere)) << "\n";
                 out << "movable = " << bool_str(rec.sphere->movable) << "\n";
                 out << "scorable = " << bool_str(rec.sphere->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cone_index = 1;
@@ -251,7 +260,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cone)) << "\n";
                 out << "movable = " << bool_str(rec.cone->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cone->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cylinder_index = 1;
@@ -268,7 +280,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cylinder)) << "\n";
                 out << "movable = " << bool_str(rec.cylinder->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cylinder->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int beam_source_index = 1;

--- a/src/Plane.cpp
+++ b/src/Plane.cpp
@@ -1,11 +1,22 @@
 #include "Plane.hpp"
 #include <cmath>
 
-Plane::Plane(const Vec3 &p, const Vec3 &n, int oid, int mid)
-	: point(p), normal(n.normalized())
+void Plane::update_basis()
 {
-	object_id = oid;
-	material_id = mid;
+        Vec3 helper = (std::fabs(normal.x) > 0.9) ? Vec3(0, 0, 1) : Vec3(1, 0, 0);
+        tangent_u = Vec3::cross(normal, helper);
+        if (tangent_u.length_squared() <= 1e-12)
+                tangent_u = Vec3::cross(normal, Vec3(0, 1, 0));
+        tangent_u = tangent_u.normalized();
+        tangent_v = Vec3::cross(tangent_u, normal);
+}
+
+Plane::Plane(const Vec3 &p, const Vec3 &n, int oid, int mid)
+        : point(p), normal(n.normalized())
+{
+        object_id = oid;
+        material_id = mid;
+        update_basis();
 }
 
 bool Plane::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
@@ -20,12 +31,15 @@ bool Plane::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	{
 		return false;
 	}
-	rec.t = t;
-	rec.p = r.at(t);
-	rec.set_face_normal(r, normal);
-	rec.material_id = material_id;
-	rec.object_id = object_id;
-	return true;
+        rec.t = t;
+        rec.p = r.at(t);
+        rec.set_face_normal(r, normal);
+        rec.material_id = material_id;
+        rec.object_id = object_id;
+        Vec3 diff = rec.p - point;
+        rec.u = Vec3::dot(diff, tangent_u);
+        rec.v = Vec3::dot(diff, tangent_v);
+        return true;
 }
 
 bool Plane::bounding_box(AABB &out) const
@@ -36,11 +50,12 @@ bool Plane::bounding_box(AABB &out) const
 
 void Plane::rotate(const Vec3 &axis, double angle)
 {
-	auto rotate_vec = [](const Vec3 &v, const Vec3 &ax, double ang)
-	{
-		double c = std::cos(ang);
-		double s = std::sin(ang);
-		return v * c + Vec3::cross(ax, v) * s + ax * Vec3::dot(ax, v) * (1 - c);
-	};
-	normal = rotate_vec(normal, axis, angle).normalized();
+        auto rotate_vec = [](const Vec3 &v, const Vec3 &ax, double ang)
+        {
+                double c = std::cos(ang);
+                double s = std::sin(ang);
+                return v * c + Vec3::cross(ax, v) * s + ax * Vec3::dot(ax, v) * (1 - c);
+        };
+        normal = rotate_vec(normal, axis, angle).normalized();
+        update_basis();
 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -158,8 +158,9 @@ void Scene::process_beams(const std::vector<Material> &mats,
                                 if (new_len > 1e-4)
                                 {
                                         Vec3 pass_orig = forward.at(closest) + forward.dir * 1e-4;
+                                        Vec3 surface = hit_mat.surface_color(*this, hit_rec);
                                         Vec3 new_color = bm->color * (1.0 - hit_mat.alpha) +
-                                                         hit_mat.base_color * hit_mat.alpha;
+                                                         surface * hit_mat.alpha;
                                         double new_intens =
                                                 bm->light_intensity * (1.0 - hit_mat.alpha);
                                        auto new_bm = std::make_shared<Laser>(

--- a/src/Sphere.cpp
+++ b/src/Sphere.cpp
@@ -1,4 +1,5 @@
 #include "Sphere.hpp"
+#include <algorithm>
 #include <cmath>
 
 Sphere::Sphere(const Vec3 &c, double r, int oid, int mid) : center(c), radius(r)
@@ -30,12 +31,20 @@ bool Sphere::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		}
 	}
 	rec.t = root;
-	rec.p = r.at(rec.t);
-	rec.material_id = material_id;
-	rec.object_id = object_id;
-	Vec3 outward = (rec.p - center) / radius;
-	rec.set_face_normal(r, outward);
-	return true;
+        rec.p = r.at(rec.t);
+        rec.material_id = material_id;
+        rec.object_id = object_id;
+        Vec3 outward = (rec.p - center) / radius;
+        rec.set_face_normal(r, outward);
+        Vec3 local = outward;
+        const double kPi = 3.14159265358979323846;
+        double phi = std::atan2(local.z, local.x);
+        double theta = std::acos(std::clamp(local.y, -1.0, 1.0));
+        rec.u = (phi + kPi) / (2.0 * kPi);
+        if (rec.u < 0.0)
+                rec.u += 1.0;
+        rec.v = theta / kPi;
+        return true;
 }
 
 bool Sphere::bounding_box(AABB &out) const

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -1,0 +1,272 @@
+#include "Texture.hpp"
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <unordered_map>
+
+namespace
+{
+
+int hex_value(char c)
+{
+        if (c >= '0' && c <= '9')
+                return c - '0';
+        if (c >= 'a' && c <= 'f')
+                return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F')
+                return c - 'A' + 10;
+        return -1;
+}
+
+Vec3 parse_hex_color(const std::string &token, bool &ok)
+{
+        ok = false;
+        if (token.size() == 7 && token[0] == '#')
+        {
+                int r = 0;
+                int g = 0;
+                int b = 0;
+                for (int i = 1; i < 7; ++i)
+                {
+                        int hv = hex_value(token[i]);
+                        if (hv < 0)
+                                return Vec3(0.0, 0.0, 0.0);
+                        if (i < 3)
+                                r = (r << 4) | hv;
+                        else if (i < 5)
+                                g = (g << 4) | hv;
+                        else
+                                b = (b << 4) | hv;
+                }
+                ok = true;
+                return Vec3(r / 255.0, g / 255.0, b / 255.0);
+        }
+        if (token.size() == 13 && token[0] == '#')
+        {
+                int r = 0;
+                int g = 0;
+                int b = 0;
+                for (int i = 1; i < 13; ++i)
+                {
+                        int hv = hex_value(token[i]);
+                        if (hv < 0)
+                                return Vec3(0.0, 0.0, 0.0);
+                        if (i < 5)
+                                r = (r << 4) | hv;
+                        else if (i < 9)
+                                g = (g << 4) | hv;
+                        else
+                                b = (b << 4) | hv;
+                }
+                ok = true;
+                return Vec3(r / 65535.0, g / 65535.0, b / 65535.0);
+        }
+        return Vec3(0.0, 0.0, 0.0);
+}
+
+std::shared_ptr<Texture> load_xpm_texture(const std::string &path, std::string &error)
+{
+        std::ifstream in(path);
+        if (!in)
+        {
+                error = "failed to open file";
+                return nullptr;
+        }
+
+        std::vector<std::string> data;
+        std::string line;
+        while (std::getline(in, line))
+        {
+                auto first = line.find('"');
+                if (first == std::string::npos)
+                        continue;
+                auto last = line.find('"', first + 1);
+                if (last == std::string::npos)
+                        continue;
+                data.emplace_back(line.substr(first + 1, last - first - 1));
+        }
+
+        if (data.empty())
+        {
+                error = "empty texture";
+                return nullptr;
+        }
+
+        std::istringstream header(data[0]);
+        int width = 0;
+        int height = 0;
+        int colors = 0;
+        int cpp = 0;
+        if (!(header >> width >> height >> colors >> cpp))
+        {
+                error = "invalid xpm header";
+                return nullptr;
+        }
+        if (width <= 0 || height <= 0 || colors <= 0 || cpp <= 0)
+        {
+                error = "invalid xpm dimensions";
+                return nullptr;
+        }
+        if (static_cast<int>(data.size()) < 1 + colors + height)
+        {
+                error = "incomplete xpm data";
+                return nullptr;
+        }
+
+        std::unordered_map<std::string, Vec3> palette;
+        palette.reserve(static_cast<size_t>(colors));
+        for (int i = 0; i < colors; ++i)
+        {
+                const std::string &entry = data[1 + i];
+                if (static_cast<int>(entry.size()) < cpp)
+                {
+                        error = "invalid palette entry";
+                        return nullptr;
+                }
+                std::string key = entry.substr(0, cpp);
+                std::string rest = entry.substr(cpp);
+                std::istringstream tokens(rest);
+                std::string token;
+                Vec3 color(0.0, 0.0, 0.0);
+                bool found = false;
+                while (tokens >> token)
+                {
+                        if (token == "c")
+                        {
+                                if (!(tokens >> token))
+                                        break;
+                                if (token == "None" || token == "none")
+                                {
+                                        color = Vec3(0.0, 0.0, 0.0);
+                                        found = true;
+                                        break;
+                                }
+                                bool ok = false;
+                                Vec3 parsed = parse_hex_color(token, ok);
+                                if (ok)
+                                {
+                                        color = parsed;
+                                        found = true;
+                                        break;
+                                }
+                        }
+                }
+                if (!found)
+                {
+                        auto hash = rest.find('#');
+                        if (hash != std::string::npos)
+                        {
+                                size_t end = rest.find_first_of(" \t\r\n", hash);
+                                std::string hex = rest.substr(hash, end - hash);
+                                bool ok = false;
+                                Vec3 parsed = parse_hex_color(hex, ok);
+                                if (ok)
+                                {
+                                        color = parsed;
+                                        found = true;
+                                }
+                        }
+                }
+                if (!found)
+                        color = Vec3(0.0, 0.0, 0.0);
+                palette[key] = color;
+        }
+
+        auto texture = std::make_shared<Texture>();
+        texture->width_ = width;
+        texture->height_ = height;
+        texture->pixels_.assign(static_cast<size_t>(width * height), Vec3(0.0, 0.0, 0.0));
+        for (int y = 0; y < height; ++y)
+        {
+                const std::string &row = data[1 + colors + y];
+                if (static_cast<int>(row.size()) < width * cpp)
+                {
+                        error = "invalid pixel row";
+                        return nullptr;
+                }
+                for (int x = 0; x < width; ++x)
+                {
+                        std::string key = row.substr(static_cast<size_t>(x * cpp), static_cast<size_t>(cpp));
+                        auto it = palette.find(key);
+                        Vec3 color = (it != palette.end()) ? it->second : Vec3(0.0, 0.0, 0.0);
+                        texture->pixels_[static_cast<size_t>(y * width + x)] = color;
+                }
+        }
+
+        return texture;
+}
+
+double wrap_coord(double value)
+{
+        double wrapped = std::fmod(value, 1.0);
+        if (wrapped < 0.0)
+                wrapped += 1.0;
+        return wrapped;
+}
+
+} // namespace
+
+Vec3 Texture::texel(int x, int y) const
+{
+        if (empty())
+                return Vec3(1.0, 1.0, 1.0);
+        int wx = width_ ? (x % width_) : 0;
+        int wy = height_ ? (y % height_) : 0;
+        if (wx < 0)
+                wx += width_;
+        if (wy < 0)
+                wy += height_;
+        return pixels_[static_cast<size_t>(wy * width_ + wx)];
+}
+
+Vec3 Texture::sample(double u, double v) const
+{
+        if (empty())
+                return Vec3(1.0, 1.0, 1.0);
+        double uw = wrap_coord(u);
+        double vw = wrap_coord(v);
+        double x = uw * static_cast<double>(width_);
+        double y = vw * static_cast<double>(height_);
+        int x0 = static_cast<int>(std::floor(x));
+        double tx = x - static_cast<double>(x0);
+        if (x0 >= width_)
+        {
+                x0 = width_ - 1;
+                tx = 0.0;
+        }
+        int y0 = static_cast<int>(std::floor(y));
+        double ty = y - static_cast<double>(y0);
+        if (y0 >= height_)
+        {
+                y0 = height_ - 1;
+                ty = 0.0;
+        }
+        int x1 = (x0 + 1) % width_;
+        int y1 = (y0 + 1) % height_;
+        Vec3 c00 = texel(x0, y0);
+        Vec3 c10 = texel(x1, y0);
+        Vec3 c01 = texel(x0, y1);
+        Vec3 c11 = texel(x1, y1);
+        Vec3 cx0 = c00 * (1.0 - tx) + c10 * tx;
+        Vec3 cx1 = c01 * (1.0 - tx) + c11 * tx;
+        return cx0 * (1.0 - ty) + cx1 * ty;
+}
+
+std::shared_ptr<Texture> load_texture(const std::string &path, std::string &error)
+{
+        std::filesystem::path fs_path(path);
+        std::string ext = fs_path.extension().string();
+        std::string lower_ext;
+        lower_ext.resize(ext.size());
+        std::transform(ext.begin(), ext.end(), lower_ext.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (lower_ext == ".xpm")
+        {
+                return load_xpm_texture(path, error);
+        }
+        error = "unsupported texture format";
+        return nullptr;
+}


### PR DESCRIPTION
## Summary
- add a texture loader and material extensions to sample external images
- compute UV coordinates for primitives and shade surfaces using texture data
- expose texture paths in scene parsing and saving for planes, spheres, cubes, cones and cylinders

## Testing
- cmake -S . -B build *(fails: missing SDL2 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce66792404832fbe082c68d29ae536