### PR TITLE
Add texture mapping support

### DIFF
--- a/inc/Hittable.hpp
+++ b/inc/Hittable.hpp
@@ -25,12 +25,15 @@ class HitRecord
 	public:
 	Vec3 p;
 	Vec3 normal;
-	double t;
-	int object_id;
-	int material_id;
-	bool front_face;
-	double beam_ratio = 0.0;
-	void set_face_normal(const Ray &r, const Vec3 &outward_normal);
+        double t;
+        int object_id;
+        int material_id;
+        bool front_face;
+        double beam_ratio = 0.0;
+        double u = 0.0;
+        double v = 0.0;
+        bool has_uv = false;
+        void set_face_normal(const Ray &r, const Vec3 &outward_normal);
 };
 
 class Hittable

--- a/inc/Plane.hpp
+++ b/inc/Plane.hpp
@@ -4,10 +4,12 @@
 
 class Plane : public Hittable
 {
-	public:
-	Vec3 point;
-	Vec3 normal;
-	Plane(const Vec3 &p, const Vec3 &n, int oid, int mid);
+        public:
+        Vec3 point;
+        Vec3 normal;
+        Vec3 tangent;
+        Vec3 bitangent;
+        Plane(const Vec3 &p, const Vec3 &n, int oid, int mid);
 
 	bool hit(const Ray &r, double tmin, double tmax,
 			 HitRecord &rec) const override;

--- a/inc/Texture.hpp
+++ b/inc/Texture.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Vec3.hpp"
+#include <string>
+#include <vector>
+
+class Texture
+{
+        public:
+        bool load_from_file(const std::string &path);
+        bool is_valid() const { return width > 0 && height > 0 && !pixels.empty(); }
+        Vec3 sample(double u, double v) const;
+        int get_width() const { return width; }
+        int get_height() const { return height; }
+
+        private:
+        int width = 0;
+        int height = 0;
+        std::vector<Vec3> pixels;
+        Vec3 get_pixel(int x, int y) const;
+};
+

--- a/inc/TextureUtils.hpp
+++ b/inc/TextureUtils.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "Vec3.hpp"
+
+class Scene;
+class Material;
+class HitRecord;
+
+Vec3 sample_surface_color(const Scene &scene, const HitRecord &rec, const Material &mat);
+double compute_effective_alpha(const Material &mat, const HitRecord &rec);
+

--- a/inc/material.hpp
+++ b/inc/material.hpp
@@ -1,7 +1,10 @@
 
 #pragma once
+#include "Texture.hpp"
 #include "Vec3.hpp"
 #include "light.hpp"
+#include <memory>
+#include <string>
 #include <vector>
 
 #define REFLECTION 50
@@ -13,11 +16,13 @@ class Material
 	Vec3 base_color; // original color stored for edits
 	double alpha = 1.0;
 	double specular_exp = 50.0;
-	double specular_k = 0.5;
-	bool mirror = false;
-	bool random_alpha = false;
-	bool checkered = false; // render as checkered pattern when true
-};
+        double specular_k = 0.5;
+        bool mirror = false;
+        bool random_alpha = false;
+        bool checkered = false; // render as checkered pattern when true
+        std::shared_ptr<Texture> texture;
+        std::string texture_path;
+}; 
 
 Vec3 phong(const Material &m, const Ambient &ambient,
 		   const std::vector<PointLight> &lights, const Vec3 &p, const Vec3 &n,

--- a/src/Cone.cpp
+++ b/src/Cone.cpp
@@ -1,5 +1,21 @@
 #include "Cone.hpp"
+#include <algorithm>
 #include <cmath>
+
+namespace
+{
+void cone_basis(const Vec3 &axis, Vec3 &u, Vec3 &v)
+{
+        Vec3 helper = std::fabs(axis.x) > 0.9 ? Vec3(0.0, 1.0, 0.0) : Vec3(1.0, 0.0, 0.0);
+        u = Vec3::cross(helper, axis).normalized();
+        if (u.length_squared() <= 1e-12)
+        {
+                helper = Vec3(0.0, 0.0, 1.0);
+                u = Vec3::cross(helper, axis).normalized();
+        }
+        v = Vec3::cross(axis, u);
+}
+}
 
 Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid)
 	: center(c), axis(ax.normalized()), radius(r), height(h)
@@ -13,8 +29,11 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	bool hit_any = false;
 	double closest = tmax;
 
-	Vec3 apex = center + axis * (height * 0.5);
-	Vec3 down = (-1) * axis;
+        Vec3 apex = center + axis * (height * 0.5);
+        Vec3 down = (-1) * axis;
+        Vec3 tex_u_axis;
+        Vec3 tex_v_axis;
+        cone_basis(axis, tex_u_axis, tex_v_axis);
 	double k = radius / height;
 
 	Vec3 oc = r.orig - apex;
@@ -44,41 +63,62 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 			{
 				continue;
 			}
-			Vec3 p = r.at(root);
-			double ax_dist = y;
-			Vec3 x_parallel = down * ax_dist;
-			Vec3 x_perp = (oc + root * r.dir) - x_parallel;
-			Vec3 normal = (x_perp - (k * k * ax_dist) * down).normalized();
-			rec.t = root;
-			rec.p = p;
-			rec.object_id = object_id;
-			rec.material_id = material_id;
-			rec.set_face_normal(r, normal);
-			closest = root;
-			hit_any = true;
-		}
-	}
+                        Vec3 p = r.at(root);
+                        double ax_dist = y;
+                        Vec3 x_parallel = down * ax_dist;
+                        Vec3 x_perp = (oc + root * r.dir) - x_parallel;
+                        Vec3 normal = (x_perp - (k * k * ax_dist) * down).normalized();
+                        rec.t = root;
+                        rec.p = p;
+                        rec.object_id = object_id;
+                        rec.material_id = material_id;
+                        rec.set_face_normal(r, normal);
+                        Vec3 axis_point = apex + down * ax_dist;
+                        Vec3 radial_vec = p - axis_point;
+                        Vec3 radial = radial_vec.length_squared() > 1e-12
+                                                ? radial_vec.normalized()
+                                                : tex_u_axis;
+                        double angle = std::atan2(Vec3::dot(radial, tex_v_axis),
+                                                  Vec3::dot(radial, tex_u_axis));
+                        double tex_u = angle / (2.0 * M_PI);
+                        if (tex_u < 0.0)
+                                tex_u += 1.0;
+                        double tex_v = ax_dist / height;
+                        tex_v = std::clamp(tex_v, 0.0, 1.0);
+                        rec.u = tex_u;
+                        rec.v = tex_v;
+                        rec.has_uv = true;
+                        closest = root;
+                        hit_any = true;
+                }
+        }
 
-	Vec3 base_center = center - axis * (height * 0.5);
+        Vec3 base_center = center - axis * (height * 0.5);
 	double denom = Vec3::dot(r.dir, (-1) * axis);
 	if (std::fabs(denom) > 1e-9)
 	{
 		double t = Vec3::dot(base_center - r.orig, (-1) * axis) / denom;
 		if (t >= tmin && t <= closest)
 		{
-			Vec3 p = r.at(t);
-			if ((p - base_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+                        Vec3 p = r.at(t);
+                        Vec3 diff = p - base_center;
+                        if (diff.length_squared() <= radius * radius)
+                        {
+                                rec.t = t;
+                                rec.p = p;
+                                rec.object_id = object_id;
+                                rec.material_id = material_id;
+                                rec.set_face_normal(r, (-1) * axis);
+                                double tex_u = Vec3::dot(diff, tex_u_axis) / (radius * 2.0) + 0.5;
+                                double tex_v = Vec3::dot(diff, tex_v_axis) / (radius * 2.0) + 0.5;
+                                rec.u = tex_u;
+                                rec.v = tex_v;
+                                rec.has_uv = true;
+                                closest = t;
+                                hit_any = true;
+                        }
+                }
+        }
 
 	return hit_any;
 }

--- a/src/Cube.cpp
+++ b/src/Cube.cpp
@@ -53,13 +53,50 @@ bool Cube::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	}
 	rec.t = tmin_local;
 	rec.p = r.at(rec.t);
-	rec.material_id = material_id;
-	rec.object_id = object_id;
+        rec.material_id = material_id;
+        rec.object_id = object_id;
 
-	Vec3 normal_world = normal_local.x * axis[0] + normal_local.y * axis[1] +
-						normal_local.z * axis[2];
-	rec.set_face_normal(r, normal_world);
-	return true;
+        Vec3 normal_world = normal_local.x * axis[0] + normal_local.y * axis[1] +
+                                                normal_local.z * axis[2];
+        rec.set_face_normal(r, normal_world);
+        Vec3 local_hit(Vec3::dot(rec.p - center, axis[0]), Vec3::dot(rec.p - center, axis[1]),
+                                       Vec3::dot(rec.p - center, axis[2]));
+        double u = 0.0;
+        double v = 0.0;
+        if (std::fabs(normal_local.x) > 0.5)
+        {
+                double u_local = (local_hit.z + half.z) / (2.0 * half.z);
+                double v_local = (local_hit.y + half.y) / (2.0 * half.y);
+                if (normal_local.x > 0)
+                        u = 1.0 - u_local;
+                else
+                        u = u_local;
+                v = v_local;
+        }
+        else if (std::fabs(normal_local.y) > 0.5)
+        {
+                double u_local = (local_hit.x + half.x) / (2.0 * half.x);
+                double v_local = (local_hit.z + half.z) / (2.0 * half.z);
+                u = u_local;
+                if (normal_local.y > 0)
+                        v = 1.0 - v_local;
+                else
+                        v = v_local;
+        }
+        else
+        {
+                double u_local = (local_hit.x + half.x) / (2.0 * half.x);
+                double v_local = (local_hit.y + half.y) / (2.0 * half.y);
+                if (normal_local.z > 0)
+                        u = u_local;
+                else
+                        u = 1.0 - u_local;
+                v = v_local;
+        }
+        rec.u = std::clamp(u, 0.0, 1.0);
+        rec.v = std::clamp(v, 0.0, 1.0);
+        rec.has_uv = true;
+        return true;
 }
 
 bool Cube::bounding_box(AABB &out) const

--- a/src/MapSaver.cpp
+++ b/src/MapSaver.cpp
@@ -200,7 +200,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(false) << "\n";
                 out << "movable = " << bool_str(rec.plane->movable) << "\n";
                 out << "scorable = " << bool_str(rec.plane->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cube_index = 1;
@@ -218,7 +221,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cube)) << "\n";
                 out << "movable = " << bool_str(rec.cube->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cube->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int sphere_index = 1;
@@ -234,7 +240,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.sphere)) << "\n";
                 out << "movable = " << bool_str(rec.sphere->movable) << "\n";
                 out << "scorable = " << bool_str(rec.sphere->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cone_index = 1;
@@ -251,7 +260,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cone)) << "\n";
                 out << "movable = " << bool_str(rec.cone->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cone->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int cylinder_index = 1;
@@ -268,7 +280,10 @@ bool MapSaver::save(const std::string &path, const Scene &scene, const Camera &c
                 out << "rotatable = " << bool_str(is_rotatable(*rec.cylinder)) << "\n";
                 out << "movable = " << bool_str(rec.cylinder->movable) << "\n";
                 out << "scorable = " << bool_str(rec.cylinder->scorable) << "\n";
-                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n\n";
+                out << "transparent = " << bool_str(material_is_transparent(*rec.mat)) << "\n";
+                if (!rec.mat->texture_path.empty())
+                        out << "texture = \"" << rec.mat->texture_path << "\"\n";
+                out << "\n";
         }
 
         int beam_source_index = 1;

--- a/src/Sphere.cpp
+++ b/src/Sphere.cpp
@@ -1,4 +1,5 @@
 #include "Sphere.hpp"
+#include <algorithm>
 #include <cmath>
 
 Sphere::Sphere(const Vec3 &c, double r, int oid, int mid) : center(c), radius(r)
@@ -33,9 +34,14 @@ bool Sphere::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 	rec.p = r.at(rec.t);
 	rec.material_id = material_id;
 	rec.object_id = object_id;
-	Vec3 outward = (rec.p - center) / radius;
-	rec.set_face_normal(r, outward);
-	return true;
+        Vec3 outward = (rec.p - center) / radius;
+        rec.set_face_normal(r, outward);
+        double phi = std::atan2(outward.z, outward.x);
+        double theta = std::asin(std::clamp(outward.y, -1.0, 1.0));
+        rec.u = 0.5 + phi / (2.0 * M_PI);
+        rec.v = 0.5 - theta / M_PI;
+        rec.has_uv = true;
+        return true;
 }
 
 bool Sphere::bounding_box(AABB &out) const

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -1,0 +1,218 @@
+#include "Texture.hpp"
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace
+{
+std::string trim(const std::string &s)
+{
+        size_t start = 0;
+        while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start])))
+                ++start;
+        size_t end = s.size();
+        while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1])))
+                --end;
+        return s.substr(start, end - start);
+}
+
+bool parse_hex_color(const std::string &token, Vec3 &out)
+{
+        if (token.empty())
+                return false;
+        if (token[0] != '#')
+                return false;
+        if (token.size() == 7)
+        {
+                auto hex_to_int = [](char c) -> int {
+                        if (c >= '0' && c <= '9')
+                                return c - '0';
+                        if (c >= 'a' && c <= 'f')
+                                return 10 + (c - 'a');
+                        if (c >= 'A' && c <= 'F')
+                                return 10 + (c - 'A');
+                        return 0;
+                };
+                int r = hex_to_int(token[1]) * 16 + hex_to_int(token[2]);
+                int g = hex_to_int(token[3]) * 16 + hex_to_int(token[4]);
+                int b = hex_to_int(token[5]) * 16 + hex_to_int(token[6]);
+                out = Vec3(r / 255.0, g / 255.0, b / 255.0);
+                return true;
+        }
+        if (token.size() == 4)
+        {
+                auto hex_to_int = [](char c) -> int {
+                        if (c >= '0' && c <= '9')
+                                return c - '0';
+                        if (c >= 'a' && c <= 'f')
+                                return 10 + (c - 'a');
+                        if (c >= 'A' && c <= 'F')
+                                return 10 + (c - 'A');
+                        return 0;
+                };
+                int r = hex_to_int(token[1]);
+                int g = hex_to_int(token[2]);
+                int b = hex_to_int(token[3]);
+                out = Vec3(r / 15.0, g / 15.0, b / 15.0);
+                return true;
+        }
+        return false;
+}
+
+bool parse_rgb_color(const std::string &token, Vec3 &out)
+{
+        if (token.size() < 5)
+                return false;
+        if (token.rfind("rgb:", 0) != 0)
+                return false;
+        std::string rest = token.substr(4);
+        std::replace(rest.begin(), rest.end(), '/', ' ');
+        std::istringstream iss(rest);
+        int r = 0;
+        int g = 0;
+        int b = 0;
+        if (!(iss >> std::hex >> r >> g >> b))
+                return false;
+        out = Vec3(r / 255.0, g / 255.0, b / 255.0);
+        return true;
+}
+
+Vec3 parse_color_token(const std::vector<std::string> &tokens)
+{
+        for (size_t i = 0; i < tokens.size(); ++i)
+        {
+                std::string lower = tokens[i];
+                std::transform(lower.begin(), lower.end(), lower.begin(),
+                               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                if (lower == "c" && i + 1 < tokens.size())
+                {
+                        Vec3 out;
+                        if (parse_hex_color(tokens[i + 1], out))
+                                return out;
+                        if (parse_rgb_color(tokens[i + 1], out))
+                                return out;
+                        std::string next_lower = tokens[i + 1];
+                        std::transform(next_lower.begin(), next_lower.end(), next_lower.begin(),
+                                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                        if (next_lower == "none")
+                                return Vec3(0.0, 0.0, 0.0);
+                }
+        }
+        return Vec3(0.0, 0.0, 0.0);
+}
+
+std::vector<std::string> split_tokens(const std::string &str)
+{
+        std::vector<std::string> tokens;
+        std::istringstream iss(str);
+        std::string token;
+        while (iss >> token)
+                tokens.push_back(token);
+        return tokens;
+}
+
+} // namespace
+
+bool Texture::load_from_file(const std::string &path)
+{
+        width = 0;
+        height = 0;
+        pixels.clear();
+        std::ifstream in(path);
+        if (!in)
+                return false;
+        std::vector<std::string> lines;
+        std::string line;
+        while (std::getline(in, line))
+        {
+                size_t start = line.find('"');
+                if (start == std::string::npos)
+                        continue;
+                size_t end = line.find_last_of('"');
+                if (end == std::string::npos || end <= start)
+                        continue;
+                std::string inner = line.substr(start + 1, end - start - 1);
+                lines.push_back(inner);
+        }
+        if (lines.empty())
+                return false;
+        std::istringstream header(lines[0]);
+        int num_colors = 0;
+        int cpp = 0;
+        if (!(header >> width >> height >> num_colors >> cpp))
+                return false;
+        if (width <= 0 || height <= 0 || num_colors <= 0 || cpp <= 0)
+                return false;
+        if (static_cast<int>(lines.size()) < 1 + num_colors + height)
+                return false;
+        std::unordered_map<std::string, Vec3> color_table;
+        for (int i = 0; i < num_colors; ++i)
+        {
+                std::string entry = lines[1 + i];
+                if (static_cast<int>(entry.size()) < cpp)
+                        return false;
+                std::string key = entry.substr(0, cpp);
+                std::string rest = entry.substr(cpp);
+                rest = trim(rest);
+                std::vector<std::string> tokens = split_tokens(rest);
+                Vec3 color = parse_color_token(tokens);
+                color_table[key] = color;
+        }
+        pixels.resize(static_cast<size_t>(width) * static_cast<size_t>(height));
+        for (int y = 0; y < height; ++y)
+        {
+                std::string row = lines[1 + num_colors + y];
+                if (static_cast<int>(row.size()) < width * cpp)
+                        return false;
+                for (int x = 0; x < width; ++x)
+                {
+                        std::string key = row.substr(x * cpp, cpp);
+                        auto it = color_table.find(key);
+                        Vec3 color = Vec3(0.0, 0.0, 0.0);
+                        if (it != color_table.end())
+                                color = it->second;
+                        pixels[static_cast<size_t>(y) * static_cast<size_t>(width) + static_cast<size_t>(x)] = color;
+                }
+        }
+        return true;
+}
+
+Vec3 Texture::get_pixel(int x, int y) const
+{
+        x = (x % width + width) % width;
+        y = (y % height + height) % height;
+        return pixels[static_cast<size_t>(y) * static_cast<size_t>(width) + static_cast<size_t>(x)];
+}
+
+Vec3 Texture::sample(double u, double v) const
+{
+        if (!is_valid())
+                return Vec3(0.0, 0.0, 0.0);
+        double u_wrapped = u - std::floor(u);
+        double v_wrapped = v - std::floor(v);
+        if (u_wrapped < 0.0)
+                u_wrapped += 1.0;
+        if (v_wrapped < 0.0)
+                v_wrapped += 1.0;
+        double x = u_wrapped * (width - 1);
+        double y = (1.0 - v_wrapped) * (height - 1);
+        int x0 = static_cast<int>(std::floor(x));
+        int y0 = static_cast<int>(std::floor(y));
+        int x1 = x0 + 1;
+        int y1 = y0 + 1;
+        double tx = x - x0;
+        double ty = y - y0;
+        Vec3 c00 = get_pixel(x0, y0);
+        Vec3 c10 = get_pixel(x1, y0);
+        Vec3 c01 = get_pixel(x0, y1);
+        Vec3 c11 = get_pixel(x1, y1);
+        Vec3 c0 = c00 * (1.0 - tx) + c10 * tx;
+        Vec3 c1 = c01 * (1.0 - tx) + c11 * tx;
+        return c0 * (1.0 - ty) + c1 * ty;
+}
+

--- a/src/TextureUtils.cpp
+++ b/src/TextureUtils.cpp
@@ -1,0 +1,49 @@
+#include "TextureUtils.hpp"
+#include "Scene.hpp"
+#include "material.hpp"
+#include "Laser.hpp"
+#include <algorithm>
+#include <cmath>
+
+Vec3 sample_surface_color(const Scene &scene, const HitRecord &rec, const Material &mat)
+{
+        Vec3 base = mat.base_color;
+        Vec3 color = mat.color;
+        if (rec.object_id >= 0 &&
+                rec.object_id < static_cast<int>(scene.objects.size()))
+        {
+                auto obj = scene.objects[rec.object_id];
+                if (obj->is_beam())
+                {
+                        auto beam = std::static_pointer_cast<Laser>(obj);
+                        base = color = beam->color;
+                }
+        }
+        if (mat.checkered)
+        {
+                Vec3 inv = Vec3(1.0, 1.0, 1.0) - base;
+                int chk = (static_cast<int>(std::floor(rec.p.x * 5)) +
+                                   static_cast<int>(std::floor(rec.p.y * 5)) +
+                                   static_cast<int>(std::floor(rec.p.z * 5))) &
+                                  1;
+                return chk ? base : inv;
+        }
+        if (mat.texture && mat.texture->is_valid() && rec.has_uv)
+        {
+                Vec3 sampled = mat.texture->sample(rec.u, rec.v);
+                return sampled;
+        }
+        return color;
+}
+
+double compute_effective_alpha(const Material &mat, const HitRecord &rec)
+{
+        double alpha = mat.alpha;
+        if (mat.random_alpha)
+        {
+                double tpos = std::clamp(rec.beam_ratio, 0.0, 1.0);
+                alpha *= (1.0 - tpos);
+        }
+        return std::clamp(alpha, 0.0, 1.0);
+}
+


### PR DESCRIPTION
## Summary
- add texture loading and sampling utilities with cached XPM support
- compute UV coordinates for planes, spheres, cubes, cones and cylinders to drive texture lookups
- update the parser, renderer and map saver to handle optional texture paths on materials

## Testing
- `cmake -S . -B build` *(fails: missing SDL2 configuration in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce66792404832fbe082c68d29ae536