### PR TITLE
Add HUD overlay bars for requirements and controls

### DIFF
--- a/inc/Renderer.hpp
+++ b/inc/Renderer.hpp
@@ -42,6 +42,7 @@ class Renderer
                                           std::vector<unsigned char> &pixels, int RW,
                                           int RH, int W, int H, int T,
                                           std::vector<Material> &mats);
+        int render_hud(const RenderState &st, SDL_Renderer *ren, int W, int H);
         Scene &scene;
         Camera &cam;
 };


### PR DESCRIPTION
## Summary
- add semi-transparent HUD bars with placeholders for level requirements and live beam statistics
- render control hints based on focus and edit state while repositioning developer overlays below the HUD
- compute beam metrics so the HUD can report active beam counts, lengths, and power levels

## Testing
- cmake -S . -B build *(fails: missing SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_68ce922dbab8832f93f82f623c3dc95c