### PR TITLE
Stop scroll input in free camera mode

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -791,7 +791,8 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                         }
                         else if (st.focused)
                         {
-                                scene.move_camera(cam, cam.up * step, mats);
+                                // Free camera mode: scrolling should have no effect.
+                                (void)step;
                         }
                 }
                 else if (g_developer_mode && st.focused && e.type == SDL_KEYDOWN &&


### PR DESCRIPTION
## Summary
- prevent the scroll wheel from moving the camera while in free camera mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cec41a86e8832f9974cd2f272c2c82