### PR TITLE
Disable scroll movement in free camera mode

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -789,10 +789,7 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                                                            OBJECT_MAX_DIST);
                                 }
                         }
-                        else if (st.focused)
-                        {
-                                scene.move_camera(cam, cam.up * step, mats);
-                        }
+                        // In free camera mode scrolling should not move the camera.
                 }
                 else if (g_developer_mode && st.focused && e.type == SDL_KEYDOWN &&
                                  e.key.keysym.scancode == SDL_SCANCODE_C)


### PR DESCRIPTION
## Summary
- prevent the mouse wheel from moving the camera while playing in free camera mode by leaving the scroll event unhandled outside of edit mode

## Testing
- cmake -S . -B build *(fails: missing SDL2 configuration files in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cec41a86e8832f9974cd2f272c2c82