### PR TITLE
Ensure beam score ignores highlight appearance

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -478,12 +478,22 @@ double integrate_spotlight_area(const Scene &scene, const std::vector<Material> 
 
 double compute_beam_score(const Scene &scene, const std::vector<Material> &mats)
 {
+        std::vector<Material> base_mats;
+        base_mats.reserve(mats.size());
+        for (const auto &mat : mats)
+        {
+                Material copy = mat;
+                copy.color = copy.base_color;
+                copy.checkered = false;
+                base_mats.push_back(std::move(copy));
+        }
+
         double score = 0.0;
         for (const auto &L : scene.lights)
         {
                 if (!L.beam_spotlight)
                         continue;
-                score += integrate_spotlight_area(scene, mats, L);
+                score += integrate_spotlight_area(scene, base_mats, L);
         }
         return score;
 }


### PR DESCRIPTION
## Summary
- ensure beam score calculations always use base material colors and ignore temporary highlight/checkered states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ced507ecc4832fb24b9d027b0746f3