### PR TITLE
Add level completion HUD prompt and menu

### DIFF
--- a/inc/LevelFinishedMenu.hpp
+++ b/inc/LevelFinishedMenu.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "AMenu.hpp"
+
+// Menu displayed when the player completes the current level.
+class LevelFinishedMenu : public AMenu {
+public:
+    LevelFinishedMenu();
+
+    // Show the menu using the provided window and renderer.
+    // Returns the action selected by the player.
+    static ButtonAction show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
+};

--- a/src/LevelFinishedMenu.cpp
+++ b/src/LevelFinishedMenu.cpp
@@ -1,0 +1,13 @@
+#include "LevelFinishedMenu.hpp"
+
+LevelFinishedMenu::LevelFinishedMenu() : AMenu("LEVEL FINISHED") {
+    title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
+    buttons.push_back(Button{"CONTINUE", ButtonAction::Resume, SDL_Color{96, 255, 128, 255}});
+    buttons.push_back(Button{"LEADERBOARD", ButtonAction::Leaderboard, SDL_Color{128, 160, 255, 255}});
+    buttons.push_back(Button{"QUIT", ButtonAction::Quit, SDL_Color{255, 96, 96, 255}});
+}
+
+ButtonAction LevelFinishedMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
+    LevelFinishedMenu menu;
+    return menu.run(window, renderer, width, height, true);
+}


### PR DESCRIPTION
## Summary
- add a LevelFinishedMenu that reuses the shared menu framework
- track quota progress in the renderer to show a blinking LEVEL FINISHED banner when requirements are met
- open the new menu when Enter is pressed during the completion state

## Testing
- cmake -S . -B build *(fails: missing SDL2 package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb901cf84832f9143e47d152bbda8