### PR TITLE
Add level completion HUD prompt and menu stub

### DIFF
--- a/inc/LevelFinishedMenu.hpp
+++ b/inc/LevelFinishedMenu.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "AMenu.hpp"
+
+// Menu shown when the player finishes the current level.
+class LevelFinishedMenu : public AMenu
+{
+        public:
+        LevelFinishedMenu();
+
+        // Display the menu and return the action picked by the player.
+        static ButtonAction show(SDL_Window *window, SDL_Renderer *renderer,
+                                 int width, int height);
+};
+

--- a/src/LevelFinishedMenu.cpp
+++ b/src/LevelFinishedMenu.cpp
@@ -1,0 +1,21 @@
+#include "LevelFinishedMenu.hpp"
+
+LevelFinishedMenu::LevelFinishedMenu() : AMenu("LEVEL FINISHED")
+{
+        title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
+        buttons.push_back(
+                Button{"CONTINUE", ButtonAction::Resume, SDL_Color{96, 255, 128, 255}});
+        buttons.push_back(Button{"LEADERBOARD", ButtonAction::Leaderboard,
+                                 SDL_Color{128, 160, 255, 255}});
+        buttons.push_back(
+                Button{"SETTINGS", ButtonAction::Settings, SDL_Color{255, 220, 96, 255}});
+        buttons.push_back(Button{"QUIT", ButtonAction::Quit, SDL_Color{255, 96, 96, 255}});
+}
+
+ButtonAction LevelFinishedMenu::show(SDL_Window *window, SDL_Renderer *renderer,
+                                     int width, int height)
+{
+        LevelFinishedMenu menu;
+        return menu.run(window, renderer, width, height, true);
+}
+


### PR DESCRIPTION
## Summary
- add a blinking center HUD section when the quota is met
- detect Enter presses during the prompt to open a new Level Finished menu
- introduce a LevelFinishedMenu placeholder that reuses the shared menu framework

## Testing
- cmake -S . -B build *(fails: missing SDL2 package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb901cf84832f9143e47d152bbda8