### PR TITLE
Add How to Play button to menus

### DIFF
--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -15,6 +15,10 @@ protected:
     bool buttons_align_bottom;
     int buttons_bottom_margin;
 
+    virtual void draw_content(SDL_Renderer *renderer, int width, int height,
+                              float scale_factor, int content_top,
+                              int content_bottom) const;
+
 public:
     explicit AMenu(const std::string &t);
     virtual ~AMenu() = default;

--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -10,6 +10,7 @@ class AMenu {
 protected:
     std::string title;
     std::vector<Button> buttons;
+    std::vector<Button> corner_buttons;
     std::vector<SDL_Color> title_colors;
 
 public:

--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -12,6 +12,8 @@ protected:
     std::vector<Button> buttons;
     std::vector<Button> corner_buttons;
     std::vector<SDL_Color> title_colors;
+    bool buttons_align_bottom;
+    int buttons_bottom_margin;
 
 public:
     explicit AMenu(const std::string &t);

--- a/inc/Button.hpp
+++ b/inc/Button.hpp
@@ -10,6 +10,7 @@ enum class ButtonAction {
     NextLevel,
     Settings,
     Leaderboard,
+    HowToPlay,
     Back,
     Quit
 };

--- a/inc/HowToPlayMenu.hpp
+++ b/inc/HowToPlayMenu.hpp
@@ -11,4 +11,8 @@ public:
     HowToPlayMenu();
     static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height,
                      bool transparent = false);
+
+protected:
+    void draw_content(SDL_Renderer *renderer, int width, int height, float scale_factor,
+                      int content_top, int content_bottom) const override;
 };

--- a/inc/HowToPlayMenu.hpp
+++ b/inc/HowToPlayMenu.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "AMenu.hpp"
+
+struct SDL_Window;
+struct SDL_Renderer;
+
+// Menu displaying how to play information
+class HowToPlayMenu : public AMenu {
+public:
+    HowToPlayMenu();
+    static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height,
+                     bool transparent = false);
+};

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -8,6 +8,10 @@
 AMenu::AMenu(const std::string &t)
     : title(t), buttons_align_bottom(false), buttons_bottom_margin(-1) {}
 
+void AMenu::draw_content(SDL_Renderer * /*renderer*/, int /*width*/, int /*height*/,
+                         float /*scale_factor*/, int /*content_top*/,
+                         int /*content_bottom*/) const {}
+
 ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, int height,
                        bool transparent) {
     bool running = true;
@@ -71,7 +75,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
         if (buttons_bottom_margin >= 0) {
             bottom_margin = static_cast<int>(buttons_bottom_margin * scale_factor);
         }
-        int start_y = title_y + title_height + title_gap;
+        int content_top = title_y + title_height + title_gap;
+        int start_y = content_top;
         if (buttons_align_bottom) {
             start_y = height - bottom_margin - total_buttons_height;
             int min_start = title_y + title_height + title_gap;
@@ -191,6 +196,11 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             CustomCharacter::draw_character(renderer, title[i], tx, title_y, c, title_scale);
             tx += (5 + 1) * title_scale;
         }
+
+        int content_bottom = buttons.empty() ? height - bottom_margin : start_y;
+        if (content_bottom < content_top)
+            content_bottom = content_top;
+        draw_content(renderer, width, height, scale_factor, content_top, content_bottom);
 
         for (auto &btn : buttons) {
             bool hover = mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -38,6 +38,19 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
         int title_scale = scale * 2;
         int title_gap = static_cast<int>(80 * scale_factor);
 
+        int corner_button_width = static_cast<int>(220 * scale_factor);
+        int corner_button_height = static_cast<int>(70 * scale_factor);
+        int corner_text_scale = static_cast<int>(3 * scale_factor);
+        int corner_margin = static_cast<int>(20 * scale_factor);
+        if (corner_button_width < 160)
+            corner_button_width = 160;
+        if (corner_button_height < 50)
+            corner_button_height = 50;
+        if (corner_text_scale < 1)
+            corner_text_scale = 1;
+        if (corner_margin < 10)
+            corner_margin = 10;
+
         int total_buttons_height = static_cast<int>(buttons.size()) * button_height +
                                    (static_cast<int>(buttons.size()) - 1) * button_gap;
         int title_height = 7 * title_scale;
@@ -54,6 +67,13 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             buttons[i].rect = {center_x,
                                start_y + static_cast<int>(i) * (button_height + button_gap),
                                button_width, button_height};
+        }
+
+        for (std::size_t i = 0; i < corner_buttons.size(); ++i) {
+            int offset = static_cast<int>(i) * (corner_button_height + corner_margin);
+            corner_buttons[i].rect = {width - corner_button_width - corner_margin,
+                                      height - corner_button_height - corner_margin - offset,
+                                      corner_button_width, corner_button_height};
         }
 
         SDL_Event event;
@@ -76,34 +96,53 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                        event.button.button == SDL_BUTTON_LEFT) {
                 int mx = event.button.x;
                 int my = event.button.y;
+                auto handle_button_click = [&](Button &btn) {
+                    if (btn.action == ButtonAction::Settings) {
+                        if (transparent && background) {
+                            SDL_RenderCopy(renderer, background, nullptr, nullptr);
+                            SDL_RenderPresent(renderer);
+                        } else {
+                            SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+                            SDL_RenderClear(renderer);
+                            SDL_RenderPresent(renderer);
+                        }
+                        SettingsMenu::show(window, renderer, width, height, transparent);
+                    } else if (btn.action == ButtonAction::Leaderboard) {
+                        if (transparent && background) {
+                            SDL_RenderCopy(renderer, background, nullptr, nullptr);
+                            SDL_RenderPresent(renderer);
+                        } else {
+                            SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+                            SDL_RenderClear(renderer);
+                            SDL_RenderPresent(renderer);
+                        }
+                        LeaderboardMenu::show(window, renderer, width, height, transparent);
+                    } else if (btn.action == ButtonAction::HowToPlay) {
+                        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "How to Play",
+                                                 "How to play instructions will be available soon.",
+                                                 window);
+                    } else {
+                        result = btn.action;
+                        running = false;
+                    }
+                };
+
+                bool handled = false;
                 for (auto &btn : buttons) {
                     if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
-                        if (btn.action == ButtonAction::Settings) {
-                            if (transparent && background) {
-                                SDL_RenderCopy(renderer, background, nullptr, nullptr);
-                                SDL_RenderPresent(renderer);
-                            } else {
-                                SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
-                                SDL_RenderClear(renderer);
-                                SDL_RenderPresent(renderer);
-                            }
-                            SettingsMenu::show(window, renderer, width, height, transparent);
-                        } else if (btn.action == ButtonAction::Leaderboard) {
-                            if (transparent && background) {
-                                SDL_RenderCopy(renderer, background, nullptr, nullptr);
-                                SDL_RenderPresent(renderer);
-                            } else {
-                                SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
-                                SDL_RenderClear(renderer);
-                                SDL_RenderPresent(renderer);
-                            }
-                            LeaderboardMenu::show(window, renderer, width, height, transparent);
-                        } else {
-                            result = btn.action;
-                            running = false;
-                        }
+                        handle_button_click(btn);
+                        handled = true;
                         break;
+                    }
+                }
+                if (!handled) {
+                    for (auto &btn : corner_buttons) {
+                        if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
+                            my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
+                            handle_button_click(btn);
+                            break;
+                        }
                     }
                 }
             }
@@ -154,6 +193,23 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                 btn.rect.x + (btn.rect.w - CustomCharacter::text_width(btn.text, scale)) / 2;
             int text_y = btn.rect.y + (btn.rect.h - 7 * scale) / 2;
             CustomCharacter::draw_text(renderer, btn.text, text_x, text_y, white, scale);
+        }
+
+        for (auto &btn : corner_buttons) {
+            bool hover = mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
+                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h;
+            SDL_Color fill = hover ? btn.hover_color : SDL_Color{0, 0, 0, 255};
+            SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+            SDL_RenderFillRect(renderer, &btn.rect);
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderDrawRect(renderer, &btn.rect);
+            int text_x = btn.rect.x +
+                         (btn.rect.w -
+                          CustomCharacter::text_width(btn.text, corner_text_scale)) /
+                             2;
+            int text_y = btn.rect.y + (btn.rect.h - 7 * corner_text_scale) / 2;
+            CustomCharacter::draw_text(renderer, btn.text, text_x, text_y, white,
+                                       corner_text_scale);
         }
         if (g_developer_mode) {
             SDL_Color red{255, 0, 0, 255};

--- a/src/HowToPlayMenu.cpp
+++ b/src/HowToPlayMenu.cpp
@@ -1,6 +1,10 @@
 #include "HowToPlayMenu.hpp"
 
+#include "CustomCharacter.hpp"
+
 #include <SDL.h>
+#include <algorithm>
+#include <sstream>
 
 HowToPlayMenu::HowToPlayMenu() : AMenu("HOW TO PLAY") {
     title_colors = {SDL_Color{255, 255, 255, 255}};
@@ -13,4 +17,125 @@ void HowToPlayMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, 
                          bool transparent) {
     HowToPlayMenu menu;
     menu.run(window, renderer, width, height, transparent);
+}
+
+void HowToPlayMenu::draw_content(SDL_Renderer *renderer, int width, int height,
+                                 float scale_factor, int content_top,
+                                 int content_bottom) const {
+    (void)height;
+    if (!renderer || content_top >= content_bottom)
+        return;
+
+    SDL_Color white{255, 255, 255, 255};
+    SDL_Color green{0, 255, 0, 255};
+    SDL_Color yellow{255, 255, 0, 255};
+    SDL_Color red{255, 0, 0, 255};
+    SDL_Color grey{160, 160, 160, 255};
+
+    int margin = static_cast<int>(80 * scale_factor);
+    if (margin < 20)
+        margin = 20;
+    int text_right = width - margin;
+    if (text_right <= margin)
+        text_right = width;
+
+    int text_scale = std::max(1, static_cast<int>(3 * scale_factor));
+    int line_height = 7 * text_scale + text_scale;
+    int small_gap = std::max(text_scale, line_height / 6);
+
+    int y = content_top;
+
+    auto clamp_y = [&]() {
+        if (y > content_bottom)
+            y = content_bottom;
+    };
+
+    auto draw_wrapped = [&](const std::string &text, int start_x, int indent_x,
+                            SDL_Color color) {
+        if (y >= content_bottom)
+            return;
+        std::istringstream stream(text);
+        std::string word;
+        std::string line;
+        int line_x = start_x;
+        int max_x = text_right;
+        if (max_x <= start_x)
+            max_x = start_x + CustomCharacter::text_width("W", text_scale);
+        while (stream >> word) {
+            std::string candidate = line.empty() ? word : line + " " + word;
+            int width_px = CustomCharacter::text_width(candidate, text_scale);
+            if (line_x + width_px > max_x && !line.empty()) {
+                CustomCharacter::draw_text(renderer, line, line_x, y, color, text_scale);
+                y += line_height;
+                if (y >= content_bottom)
+                    return;
+                line = word;
+                line_x = indent_x;
+            } else {
+                line = candidate;
+            }
+        }
+        if (!line.empty() && y < content_bottom) {
+            CustomCharacter::draw_text(renderer, line, line_x, y, color, text_scale);
+        }
+    };
+
+    auto next_line = [&]() {
+        y += line_height;
+        clamp_y();
+    };
+
+    auto add_gap = [&](int gap) {
+        y += gap;
+        clamp_y();
+    };
+
+    auto draw_paragraph = [&](const std::string &text) {
+        draw_wrapped(text, margin, margin, white);
+        next_line();
+        add_gap(small_gap);
+    };
+
+    auto draw_bullet = [&](const std::string &label, SDL_Color color,
+                           const std::string &description) {
+        if (y >= content_bottom)
+            return;
+        int x = margin;
+        int bullet_width = CustomCharacter::text_width("- ", text_scale);
+        CustomCharacter::draw_text(renderer, "- ", x, y, white, text_scale);
+        x += bullet_width;
+        CustomCharacter::draw_text(renderer, label, x, y, color, text_scale);
+        x += CustomCharacter::text_width(label, text_scale);
+        int space_width = CustomCharacter::text_width(" ", text_scale);
+        CustomCharacter::draw_text(renderer, " ", x, y, white, text_scale);
+        x += space_width;
+        draw_wrapped(description, x, x, white);
+        next_line();
+        add_gap(small_gap / 2);
+    };
+
+    draw_paragraph(
+        "Use the available objects to steer the laser beam from the white source sphere "
+        "to the black target sphere.");
+    draw_paragraph(
+        "Earn points by illuminating object surfaces; the total score must reach each "
+        "level's quota.");
+
+    draw_wrapped("Object rules:", margin, margin, white);
+    next_line();
+    add_gap(small_gap / 2);
+
+    draw_bullet("Green", green, "objects can both move and rotate.");
+    draw_bullet("Yellow", yellow, "objects rotate but can't move.");
+    draw_bullet("Red", red, "objects stay put - you can't move or rotate them.");
+    draw_bullet("Grey", grey, "objects just block the beam; they don't score points.");
+
+    add_gap(small_gap);
+
+    draw_paragraph(
+        "Remember that the laser fades with distance and stops once it reaches its set "
+        "length.");
+    draw_paragraph(
+        "Hit the target and reach the quota to clear the level, or optimize your setup to "
+        "climb the leaderboard.");
 }

--- a/src/HowToPlayMenu.cpp
+++ b/src/HowToPlayMenu.cpp
@@ -3,6 +3,7 @@
 #include <SDL.h>
 
 HowToPlayMenu::HowToPlayMenu() : AMenu("HOW TO PLAY") {
+    title_colors = {SDL_Color{255, 255, 255, 255}};
     buttons_align_bottom = true;
     buttons_bottom_margin = 60;
     buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});

--- a/src/HowToPlayMenu.cpp
+++ b/src/HowToPlayMenu.cpp
@@ -1,0 +1,15 @@
+#include "HowToPlayMenu.hpp"
+
+#include <SDL.h>
+
+HowToPlayMenu::HowToPlayMenu() : AMenu("HOW TO PLAY") {
+    buttons_align_bottom = true;
+    buttons_bottom_margin = 60;
+    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+}
+
+void HowToPlayMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height,
+                         bool transparent) {
+    HowToPlayMenu menu;
+    menu.run(window, renderer, width, height, transparent);
+}

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -6,6 +6,8 @@ MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
     buttons.push_back(Button{"LEADERBOARD", ButtonAction::Leaderboard, SDL_Color{0, 0, 255, 255}});
     buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, SDL_Color{255, 255, 0, 255}});
     buttons.push_back(Button{"QUIT", ButtonAction::Quit, SDL_Color{255, 0, 0, 255}});
+    corner_buttons.push_back(
+        Button{"HOW TO PLAY", ButtonAction::HowToPlay, SDL_Color{80, 80, 80, 255}});
 }
 
 bool MainMenu::show(int width, int height) {

--- a/src/PauseMenu.cpp
+++ b/src/PauseMenu.cpp
@@ -6,6 +6,8 @@ PauseMenu::PauseMenu() : AMenu("PAUSE") {
     buttons.push_back(Button{"LEADERBOARD", ButtonAction::Leaderboard, SDL_Color{0, 0, 255, 255}});
     buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, SDL_Color{255, 255, 0, 255}});
     buttons.push_back(Button{"QUIT", ButtonAction::Quit, SDL_Color{255, 0, 0, 255}});
+    corner_buttons.push_back(
+        Button{"HOW TO PLAY", ButtonAction::HowToPlay, SDL_Color{80, 80, 80, 255}});
 }
 
 bool PauseMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {


### PR DESCRIPTION
## Summary
- add a new button action and shared support for drawing small corner buttons in menus
- show a "HOW TO PLAY" button in the main and pause menus that displays a placeholder message

## Testing
- cmake -S . -B build *(fails: missing SDL2 package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d06ec3bf3c832f8e78305498b528be