### PR TITLE
Load default level without CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Puzzle game based on miniRT 42School project.
 
 ### Windows
 ```bash
-./build/minirt.exe scenes/[map].toml
+./build/minirt.exe
 ```
 
 ### Linux
 ```bash
-./build/minirt scenes/[map].toml
+./build/minirt
 ```
 
-The `scenes` directory contains sample `.toml` scenes.
+The game automatically loads the `scenes/level_1.toml` scene at startup. Other sample `.toml` scenes are available in the `scenes` directory.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Puzzle game based on miniRT 42School project.
    ```
 3. Clone this repository:
    ```bash
-   git clone https://github.com/<your-username>/minirt_game.git
+   git clone https://github.com/Jzackiewicz/minirt_game.git
    ```
 4. Configure and build the project with CMake:
    ```bash
@@ -52,5 +52,3 @@ Puzzle game based on miniRT 42School project.
 ```bash
 ./build/minirt
 ```
-
-The game automatically loads the `scenes/level_1.toml` scene at startup. Other sample `.toml` scenes are available in the `scenes` directory.

--- a/inc/CommandLine.hpp
+++ b/inc/CommandLine.hpp
@@ -3,10 +3,10 @@
 #include <string>
 
 /**
- * Parses command line arguments.
+ * Prepares the default scene path.
  *
- * @param argc Argument count.
- * @param argv Argument values.
+ * @param argc Argument count (unused).
+ * @param argv Argument values (unused).
  * @param scene_path Output path to scene file.
  * @return True on success.
  */

--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -1,13 +1,9 @@
 #include "CommandLine.hpp"
-#include <iostream>
 
 bool parse_arguments(int argc, char **argv, std::string &scene_path)
 {
-        if (argc != 2)
-        {
-                std::cerr << "Usage: minirt <scene.toml>\n";
-                return false;
-        }
-        scene_path = argv[1];
-        return true;
+    (void)argc;
+    (void)argv;
+    scene_path = "scenes/level_1.toml";
+    return true;
 }


### PR DESCRIPTION
## Summary
- remove the requirement for command line arguments and always select the level_1 scene
- refresh the command line helper documentation and README usage instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0a57b7180832fb31f2cb13c57f931