### PR TITLE
Adjust menu highlight colors to pastel palette

### DIFF
--- a/inc/Button.hpp
+++ b/inc/Button.hpp
@@ -15,6 +15,14 @@ enum class ButtonAction {
     Quit
 };
 
+namespace MenuColors {
+constexpr SDL_Color PastelGreen{96, 255, 128, 255};
+constexpr SDL_Color PastelBlue{96, 128, 255, 255};
+constexpr SDL_Color PastelYellow{255, 224, 128, 255};
+constexpr SDL_Color PastelRed{255, 96, 96, 255};
+constexpr SDL_Color PastelGray{176, 176, 176, 255};
+} // namespace MenuColors
+
 // Represents an interactive button in a menu
 class Button {
 public:

--- a/src/HowToPlayMenu.cpp
+++ b/src/HowToPlayMenu.cpp
@@ -13,7 +13,7 @@ HowToPlayMenu::HowToPlayMenu() : AMenu("HOW TO PLAY") {
     buttons_align_bottom = true;
     title_top_margin = 60;
     buttons_bottom_margin = 40;
-    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+    buttons.push_back(Button{"BACK", ButtonAction::Back, MenuColors::PastelRed});
 }
 
 void HowToPlayMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height,

--- a/src/LeaderboardMenu.cpp
+++ b/src/LeaderboardMenu.cpp
@@ -37,7 +37,7 @@ load_scores(const std::string &filename) {
 
 LeaderboardMenu::LeaderboardMenu() : AMenu("LEADERBOARD"), scores(load_scores("leaderboard.yaml")) {
     title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
-    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+    buttons.push_back(Button{"BACK", ButtonAction::Back, MenuColors::PastelRed});
 }
 
 void LeaderboardMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height,

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -2,12 +2,13 @@
 #include <SDL.h>
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
-    buttons.push_back(Button{"PLAY", ButtonAction::Play, SDL_Color{0, 255, 0, 255}});
-    buttons.push_back(Button{"LEADERBOARD", ButtonAction::Leaderboard, SDL_Color{0, 0, 255, 255}});
-    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, SDL_Color{255, 255, 0, 255}});
-    buttons.push_back(Button{"QUIT", ButtonAction::Quit, SDL_Color{255, 0, 0, 255}});
+    buttons.push_back(Button{"PLAY", ButtonAction::Play, MenuColors::PastelGreen});
+    buttons.push_back(
+        Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
+    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
+    buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
     corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, SDL_Color{80, 80, 80, 255}});
+        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
 }
 
 bool MainMenu::show(int width, int height) {

--- a/src/PauseMenu.cpp
+++ b/src/PauseMenu.cpp
@@ -2,12 +2,13 @@
 
 PauseMenu::PauseMenu() : AMenu("PAUSE") {
     title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
-    buttons.push_back(Button{"RESUME", ButtonAction::Resume, SDL_Color{0, 255, 0, 255}});
-    buttons.push_back(Button{"LEADERBOARD", ButtonAction::Leaderboard, SDL_Color{0, 0, 255, 255}});
-    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, SDL_Color{255, 255, 0, 255}});
-    buttons.push_back(Button{"QUIT", ButtonAction::Quit, SDL_Color{255, 0, 0, 255}});
+    buttons.push_back(Button{"RESUME", ButtonAction::Resume, MenuColors::PastelGreen});
+    buttons.push_back(
+        Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
+    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
+    buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
     corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, SDL_Color{80, 80, 80, 255}});
+        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
 }
 
 bool PauseMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {

--- a/src/SettingsMenu.cpp
+++ b/src/SettingsMenu.cpp
@@ -339,8 +339,8 @@ std::string ResolutionSection::current() const {
 
 SettingsMenu::SettingsMenu() : AMenu("SETTINGS") {
     // Bottom buttons
-    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
-    buttons.push_back(Button{"APPLY", ButtonAction::None, SDL_Color{0, 255, 0, 255}});
+    buttons.push_back(Button{"BACK", ButtonAction::Back, MenuColors::PastelRed});
+    buttons.push_back(Button{"APPLY", ButtonAction::None, MenuColors::PastelGreen});
 }
 
 void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height,


### PR DESCRIPTION
## Summary
- introduce shared pastel hover color constants for menus
- update main, pause, leaderboard, settings, and how-to-play menus to use the pastel palette

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ab9a6a00832fbdbb80751a042216