### PR TITLE
Update main menu layout

### DIFF
--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -19,6 +19,9 @@ protected:
     virtual void draw_content(SDL_Renderer *renderer, int width, int height, int scale,
                               int title_scale, int title_x, int title_y, int title_height,
                               int title_gap, int buttons_start_y);
+    virtual int compute_total_buttons_height(int button_height, int button_gap) const;
+    virtual void layout_buttons(int width, int height, int start_y, int button_width,
+                                int button_height, int button_gap);
 
 public:
     explicit AMenu(const std::string &t);

--- a/inc/Button.hpp
+++ b/inc/Button.hpp
@@ -21,6 +21,7 @@ constexpr SDL_Color PastelBlue{96, 128, 255, 255};
 constexpr SDL_Color PastelYellow{255, 224, 128, 255};
 constexpr SDL_Color PastelRed{255, 96, 96, 255};
 constexpr SDL_Color PastelGray{176, 176, 176, 255};
+constexpr SDL_Color PastelPurple{208, 160, 255, 255};
 } // namespace MenuColors
 
 // Represents an interactive button in a menu

--- a/inc/MainMenu.hpp
+++ b/inc/MainMenu.hpp
@@ -3,6 +3,11 @@
 
 // Main menu displayed before starting the game
 class MainMenu : public AMenu {
+protected:
+    int compute_total_buttons_height(int button_height, int button_gap) const override;
+    void layout_buttons(int width, int height, int start_y, int button_width,
+                        int button_height, int button_gap) override;
+
 public:
     MainMenu();
     static bool show(int width, int height);

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -54,11 +54,7 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
         if (corner_margin < 10)
             corner_margin = 10;
 
-        int total_buttons_height = 0;
-        if (!buttons.empty()) {
-            total_buttons_height = static_cast<int>(buttons.size()) * button_height +
-                                   (static_cast<int>(buttons.size()) - 1) * button_gap;
-        }
+        int total_buttons_height = compute_total_buttons_height(button_height, button_gap);
         int title_height = 7 * title_scale;
         int top_margin = (height - title_height - title_gap - total_buttons_height) / 2;
         if (title_top_margin >= 0) {
@@ -70,7 +66,6 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
         int title_x = width / 2 - CustomCharacter::text_width(title, title_scale) / 2;
         int title_y = top_margin;
 
-        int center_x = width / 2 - button_width / 2;
         int bottom_margin = top_margin;
         if (buttons_bottom_margin >= 0) {
             bottom_margin = static_cast<int>(buttons_bottom_margin * scale_factor);
@@ -82,11 +77,7 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             if (start_y < min_start)
                 start_y = min_start;
         }
-        for (std::size_t i = 0; i < buttons.size(); ++i) {
-            buttons[i].rect = {center_x,
-                               start_y + static_cast<int>(i) * (button_height + button_gap),
-                               button_width, button_height};
-        }
+        layout_buttons(width, height, start_y, button_width, button_height, button_gap);
 
         for (std::size_t i = 0; i < corner_buttons.size(); ++i) {
             int offset = static_cast<int>(i) * (corner_button_height + corner_margin);
@@ -136,7 +127,7 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                     } else if (btn.action == ButtonAction::HowToPlay) {
                         present_background();
                         HowToPlayMenu::show(window, renderer, width, height, transparent);
-                    } else {
+                    } else if (btn.action != ButtonAction::None) {
                         result = btn.action;
                         running = false;
                     }
@@ -242,6 +233,23 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
     if (background)
         SDL_DestroyTexture(background);
     return result;
+}
+
+int AMenu::compute_total_buttons_height(int button_height, int button_gap) const {
+    if (buttons.empty())
+        return 0;
+    int count = static_cast<int>(buttons.size());
+    return count * button_height + (count - 1) * button_gap;
+}
+
+void AMenu::layout_buttons(int width, int, int start_y, int button_width, int button_height,
+                           int button_gap) {
+    int center_x = width / 2 - button_width / 2;
+    for (std::size_t i = 0; i < buttons.size(); ++i) {
+        buttons[i].rect = {center_x,
+                           start_y + static_cast<int>(i) * (button_height + button_gap),
+                           button_width, button_height};
+    }
 }
 
 void AMenu::draw_content(SDL_Renderer *, int, int, int, int, int, int, int, int, int) {}

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -1,14 +1,15 @@
 #include "MainMenu.hpp"
 #include <SDL.h>
+#include <cstddef>
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
     buttons.push_back(Button{"PLAY", ButtonAction::Play, MenuColors::PastelGreen});
+    buttons.push_back(Button{"Tutorial", ButtonAction::None, MenuColors::PastelPurple});
+    buttons.push_back(Button{"How to play", ButtonAction::HowToPlay, MenuColors::PastelGray});
     buttons.push_back(
-        Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
-    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
-    buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
-    corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
+        Button{"Leaderboard", ButtonAction::Leaderboard, MenuColors::PastelBlue});
+    buttons.push_back(Button{"Settings", ButtonAction::Settings, MenuColors::PastelYellow});
+    buttons.push_back(Button{"Quit", ButtonAction::Quit, MenuColors::PastelRed});
 }
 
 bool MainMenu::show(int width, int height) {
@@ -33,4 +34,61 @@ bool MainMenu::show(int width, int height) {
     SDL_DestroyWindow(window);
     SDL_Quit();
     return action == ButtonAction::Play;
+}
+
+int MainMenu::compute_total_buttons_height(int button_height, int button_gap) const {
+    if (buttons.size() == 6)
+        return 3 * button_height + 2 * button_gap;
+    return AMenu::compute_total_buttons_height(button_height, button_gap);
+}
+
+void MainMenu::layout_buttons(int width, int height, int start_y, int button_width,
+                              int button_height, int button_gap) {
+    if (buttons.size() != 6) {
+        AMenu::layout_buttons(width, height, start_y, button_width, button_height, button_gap);
+        return;
+    }
+
+    (void)height;
+    int column_gap = button_gap * 2;
+    int total_width = button_width * 2 + column_gap;
+    if (total_width > width) {
+        column_gap = button_gap;
+        total_width = button_width * 2 + column_gap;
+        if (total_width > width) {
+            AMenu::layout_buttons(width, height, start_y, button_width, button_height,
+                                  button_gap);
+            return;
+        }
+    }
+
+    int left_x = width / 2 - total_width / 2;
+    int right_x_base = left_x + button_width + column_gap;
+    if (left_x < 0 || right_x_base + button_width > width) {
+        AMenu::layout_buttons(width, height, start_y, button_width, button_height, button_gap);
+        return;
+    }
+
+    int right_center = right_x_base + button_width / 2;
+    int rows = 3;
+    for (int row = 0; row < rows; ++row) {
+        int y = start_y + row * (button_height + button_gap);
+        std::size_t left_index = static_cast<std::size_t>(row * 2);
+        std::size_t right_index = left_index + 1;
+        if (right_index >= buttons.size())
+            break;
+
+        auto &left_button = buttons[left_index];
+        left_button.rect = {left_x, y, button_width, button_height};
+
+        auto &right_button = buttons[right_index];
+        int right_width = button_width;
+        if (row == 0) {
+            right_width = (button_width * 3) / 4;
+            if (right_width < 1)
+                right_width = 1;
+        }
+        int right_x = right_center - right_width / 2;
+        right_button.rect = {right_x, y, right_width, button_height};
+    }
 }


### PR DESCRIPTION
## Summary
- restructure the main menu into a two-column, three-row grid and add the Tutorial button with a pastel-purple highlight
- extend the shared menu base to support custom button layouts and ignore no-op button actions
- keep the tutorial entry inactive while leaving other menus unaffected

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b05ba0f0832f9ac0cf3fd6616148