### PR TITLE
Adjust main menu layout for two-column grid

### DIFF
--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -19,6 +19,9 @@ protected:
     virtual void draw_content(SDL_Renderer *renderer, int width, int height, int scale,
                               int title_scale, int title_x, int title_y, int title_height,
                               int title_gap, int buttons_start_y);
+    virtual void layout_buttons(int width, int height, int scale_factor, int button_width,
+                                int button_height, int button_gap, int start_y,
+                                int center_x);
 
 public:
     explicit AMenu(const std::string &t);

--- a/inc/Button.hpp
+++ b/inc/Button.hpp
@@ -11,6 +11,7 @@ enum class ButtonAction {
     Settings,
     Leaderboard,
     HowToPlay,
+    Tutorial,
     Back,
     Quit
 };
@@ -21,6 +22,7 @@ constexpr SDL_Color PastelBlue{96, 128, 255, 255};
 constexpr SDL_Color PastelYellow{255, 224, 128, 255};
 constexpr SDL_Color PastelRed{255, 96, 96, 255};
 constexpr SDL_Color PastelGray{176, 176, 176, 255};
+constexpr SDL_Color PastelPurple{192, 160, 255, 255};
 } // namespace MenuColors
 
 // Represents an interactive button in a menu

--- a/inc/MainMenu.hpp
+++ b/inc/MainMenu.hpp
@@ -6,4 +6,9 @@ class MainMenu : public AMenu {
 public:
     MainMenu();
     static bool show(int width, int height);
+
+protected:
+    void layout_buttons(int width, int height, int scale_factor, int button_width,
+                        int button_height, int button_gap, int start_y,
+                        int center_x) override;
 };

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -82,11 +82,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             if (start_y < min_start)
                 start_y = min_start;
         }
-        for (std::size_t i = 0; i < buttons.size(); ++i) {
-            buttons[i].rect = {center_x,
-                               start_y + static_cast<int>(i) * (button_height + button_gap),
-                               button_width, button_height};
-        }
+        layout_buttons(width, height, scale, button_width, button_height, button_gap,
+                       start_y, center_x);
 
         for (std::size_t i = 0; i < corner_buttons.size(); ++i) {
             int offset = static_cast<int>(i) * (corner_button_height + corner_margin);
@@ -136,6 +133,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                     } else if (btn.action == ButtonAction::HowToPlay) {
                         present_background();
                         HowToPlayMenu::show(window, renderer, width, height, transparent);
+                    } else if (btn.action == ButtonAction::Tutorial) {
+                        // Tutorial menu not implemented yet.
                     } else {
                         result = btn.action;
                         running = false;
@@ -245,3 +244,12 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
 }
 
 void AMenu::draw_content(SDL_Renderer *, int, int, int, int, int, int, int, int, int) {}
+
+void AMenu::layout_buttons(int, int, int, int button_width, int button_height, int button_gap,
+                           int start_y, int center_x) {
+    for (std::size_t i = 0; i < buttons.size(); ++i) {
+        buttons[i].rect = {center_x,
+                           start_y + static_cast<int>(i) * (button_height + button_gap),
+                           button_width, button_height};
+    }
+}

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -3,12 +3,12 @@
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
     buttons.push_back(Button{"PLAY", ButtonAction::Play, MenuColors::PastelGreen});
+    buttons.push_back(Button{"TUTORIAL", ButtonAction::Tutorial, MenuColors::PastelPurple});
+    buttons.push_back(Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
     buttons.push_back(
         Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
     buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
     buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
-    corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
 }
 
 bool MainMenu::show(int width, int height) {
@@ -33,4 +33,38 @@ bool MainMenu::show(int width, int height) {
     SDL_DestroyWindow(window);
     SDL_Quit();
     return action == ButtonAction::Play;
+}
+
+void MainMenu::layout_buttons(int width, int height, int scale, int button_width,
+                              int button_height, int button_gap, int start_y,
+                              int center_x) {
+    (void)height;
+    (void)scale;
+    (void)center_x;
+    if (buttons.size() != 6) {
+        AMenu::layout_buttons(width, height, scale, button_width, button_height, button_gap,
+                              start_y, center_x);
+        return;
+    }
+
+    int column_gap = button_gap;
+    int left_width = button_width;
+    int right_max_width = button_width;
+    int tutorial_width = (button_width * 3) / 4;
+    int layout_width = left_width + column_gap + right_max_width;
+    int left_x = (width - layout_width) / 2;
+    int right_x = left_x + left_width + column_gap;
+    int tutorial_x = right_x + (right_max_width - tutorial_width) / 2;
+
+    int row_y = start_y;
+    buttons[0].rect = {left_x, row_y, left_width, button_height};
+    buttons[1].rect = {tutorial_x, row_y, tutorial_width, button_height};
+
+    row_y += button_height + button_gap;
+    buttons[2].rect = {left_x, row_y, left_width, button_height};
+    buttons[3].rect = {right_x, row_y, right_max_width, button_height};
+
+    row_y += button_height + button_gap;
+    buttons[4].rect = {left_x, row_y, left_width, button_height};
+    buttons[5].rect = {right_x, row_y, right_max_width, button_height};
 }


### PR DESCRIPTION
## Summary
- extend the generic menu layout helper to allow custom button placement
- arrange the main menu as a two-column, three-row grid with a smaller Tutorial button
- add a pastel-purple Tutorial button stub that currently does not trigger any action

## Testing
- cmake -S . -B build *(fails: missing SDL2 package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b05ba0f0832f9ac0cf3fd6616148