### PR TITLE
Adjust main menu layout with tutorial button

### DIFF
--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -19,6 +19,10 @@ protected:
     virtual void draw_content(SDL_Renderer *renderer, int width, int height, int scale,
                               int title_scale, int title_x, int title_y, int title_height,
                               int title_gap, int buttons_start_y);
+    virtual void layout_buttons(int width, int height, int button_width, int button_height,
+                                int button_gap, int start_y, int center_x,
+                                float scale_factor);
+    virtual int layout_total_height(int button_height, int button_gap) const;
 
 public:
     explicit AMenu(const std::string &t);

--- a/inc/Button.hpp
+++ b/inc/Button.hpp
@@ -11,6 +11,7 @@ enum class ButtonAction {
     Settings,
     Leaderboard,
     HowToPlay,
+    Tutorial,
     Back,
     Quit
 };
@@ -21,6 +22,7 @@ constexpr SDL_Color PastelBlue{96, 128, 255, 255};
 constexpr SDL_Color PastelYellow{255, 224, 128, 255};
 constexpr SDL_Color PastelRed{255, 96, 96, 255};
 constexpr SDL_Color PastelGray{176, 176, 176, 255};
+constexpr SDL_Color PastelPurple{200, 160, 255, 255};
 } // namespace MenuColors
 
 // Represents an interactive button in a menu

--- a/inc/MainMenu.hpp
+++ b/inc/MainMenu.hpp
@@ -3,6 +3,12 @@
 
 // Main menu displayed before starting the game
 class MainMenu : public AMenu {
+protected:
+    void layout_buttons(int width, int height, int button_width, int button_height,
+                        int button_gap, int start_y, int center_x,
+                        float scale_factor) override;
+    int layout_total_height(int button_height, int button_gap) const override;
+
 public:
     MainMenu();
     static bool show(int width, int height);

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -9,6 +9,25 @@ AMenu::AMenu(const std::string &t)
     : title(t), buttons_align_bottom(false), buttons_bottom_margin(-1),
       title_top_margin(-1) {}
 
+int AMenu::layout_total_height(int button_height, int button_gap) const {
+    if (buttons.empty()) {
+        return 0;
+    }
+    return static_cast<int>(buttons.size()) * button_height +
+           (static_cast<int>(buttons.size()) - 1) * button_gap;
+}
+
+void AMenu::layout_buttons(int width, int height, int button_width, int button_height,
+                           int button_gap, int start_y, int center_x, float) {
+    (void)width;
+    (void)height;
+    for (std::size_t i = 0; i < buttons.size(); ++i) {
+        buttons[i].rect = {center_x,
+                           start_y + static_cast<int>(i) * (button_height + button_gap),
+                           button_width, button_height};
+    }
+}
+
 ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, int height,
                        bool transparent) {
     bool running = true;
@@ -54,11 +73,7 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
         if (corner_margin < 10)
             corner_margin = 10;
 
-        int total_buttons_height = 0;
-        if (!buttons.empty()) {
-            total_buttons_height = static_cast<int>(buttons.size()) * button_height +
-                                   (static_cast<int>(buttons.size()) - 1) * button_gap;
-        }
+        int total_buttons_height = layout_total_height(button_height, button_gap);
         int title_height = 7 * title_scale;
         int top_margin = (height - title_height - title_gap - total_buttons_height) / 2;
         if (title_top_margin >= 0) {
@@ -82,11 +97,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             if (start_y < min_start)
                 start_y = min_start;
         }
-        for (std::size_t i = 0; i < buttons.size(); ++i) {
-            buttons[i].rect = {center_x,
-                               start_y + static_cast<int>(i) * (button_height + button_gap),
-                               button_width, button_height};
-        }
+        layout_buttons(width, height, button_width, button_height, button_gap, start_y,
+                       center_x, scale_factor);
 
         for (std::size_t i = 0; i < corner_buttons.size(); ++i) {
             int offset = static_cast<int>(i) * (corner_button_height + corner_margin);
@@ -136,6 +148,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                     } else if (btn.action == ButtonAction::HowToPlay) {
                         present_background();
                         HowToPlayMenu::show(window, renderer, width, height, transparent);
+                    } else if (btn.action == ButtonAction::Tutorial) {
+                        // Tutorial is not implemented yet.
                     } else {
                         result = btn.action;
                         running = false;

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -2,13 +2,72 @@
 #include <SDL.h>
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
-    buttons.push_back(Button{"PLAY", ButtonAction::Play, MenuColors::PastelGreen});
+    buttons.push_back(Button{"Play", ButtonAction::Play, MenuColors::PastelGreen});
     buttons.push_back(
-        Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
-    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
-    buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
-    corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
+        Button{"Tutorial", ButtonAction::Tutorial, MenuColors::PastelPurple});
+    buttons.push_back(
+        Button{"How to play", ButtonAction::HowToPlay, MenuColors::PastelGray});
+    buttons.push_back(
+        Button{"Leaderboard", ButtonAction::Leaderboard, MenuColors::PastelBlue});
+    buttons.push_back(
+        Button{"Settings", ButtonAction::Settings, MenuColors::PastelYellow});
+    buttons.push_back(Button{"Quit", ButtonAction::Quit, MenuColors::PastelRed});
+}
+
+int MainMenu::layout_total_height(int button_height, int button_gap) const {
+    if (buttons.size() < 6) {
+        return AMenu::layout_total_height(button_height, button_gap);
+    }
+    int rows = 3;
+    return rows * button_height + (rows - 1) * button_gap;
+}
+
+void MainMenu::layout_buttons(int width, int height, int button_width, int button_height,
+                              int button_gap, int start_y, int center_x,
+                              float scale_factor) {
+    if (buttons.size() < 6) {
+        AMenu::layout_buttons(width, height, button_width, button_height, button_gap, start_y,
+                              center_x, scale_factor);
+        return;
+    }
+
+    int column_gap = button_gap;
+    int grid_width = button_width * 2 + column_gap;
+    if (grid_width > width) {
+        column_gap = width - button_width * 2;
+        if (column_gap < 0) {
+            column_gap = 0;
+        }
+        grid_width = button_width * 2 + column_gap;
+        if (grid_width > width) {
+            AMenu::layout_buttons(width, height, button_width, button_height, button_gap,
+                                  start_y, center_x, scale_factor);
+            return;
+        }
+    }
+
+    int left_x = (width - grid_width) / 2;
+    if (left_x < 0) {
+        left_x = 0;
+    }
+    int right_slot_x = left_x + button_width + column_gap;
+
+    int tutorial_width = static_cast<int>(static_cast<float>(button_width) * 0.75f);
+    if (tutorial_width < 1) {
+        tutorial_width = 1;
+    }
+    int tutorial_x = right_slot_x + (button_width - tutorial_width) / 2;
+
+    auto row_y = [&](int row) {
+        return start_y + row * (button_height + button_gap);
+    };
+
+    buttons[0].rect = {left_x, row_y(0), button_width, button_height};
+    buttons[1].rect = {tutorial_x, row_y(0), tutorial_width, button_height};
+    buttons[2].rect = {left_x, row_y(1), button_width, button_height};
+    buttons[3].rect = {right_slot_x, row_y(1), button_width, button_height};
+    buttons[4].rect = {left_x, row_y(2), button_width, button_height};
+    buttons[5].rect = {right_slot_x, row_y(2), button_width, button_height};
 }
 
 bool MainMenu::show(int width, int height) {


### PR DESCRIPTION
## Summary
- add tutorial button and reorganize main menu buttons into a two-column layout with proper sizing
- extend the menu base class so derived menus can customize button placement and total height calculations

## Testing
- cmake -S . -B build *(fails: SDL2 development files are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b05ba0f0832f9ac0cf3fd6616148