### PR TITLE
Refine menu layouts

### DIFF
--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <SDL.h>
+#include <functional>
 #include <string>
 #include <vector>
 #include "Button.hpp"
@@ -16,6 +17,17 @@ protected:
     int buttons_bottom_margin;
     int title_top_margin;
 
+    virtual int button_rows() const;
+    virtual void adjust_button_metrics(float scale_factor, int &button_width,
+                                       int &button_height, int &button_gap) const;
+    virtual void layout_buttons(std::vector<Button> &buttons, int width, int height,
+                                float scale_factor, int button_width, int button_height,
+                                int button_gap, int start_y, int center_x);
+    void layout_two_column_grid(std::vector<Button> &buttons, int width,
+                                int button_height, int vertical_gap, int start_y,
+                                int left_column_width, int right_column_width,
+                                int column_gap,
+                                const std::function<void(std::size_t, SDL_Rect &)> &adjust_rect = {});
     virtual void draw_content(SDL_Renderer *renderer, int width, int height, int scale,
                               int title_scale, int title_x, int title_y, int title_height,
                               int title_gap, int buttons_start_y);

--- a/inc/Button.hpp
+++ b/inc/Button.hpp
@@ -11,6 +11,7 @@ enum class ButtonAction {
     Settings,
     Leaderboard,
     HowToPlay,
+    Tutorial,
     Back,
     Quit
 };
@@ -21,6 +22,7 @@ constexpr SDL_Color PastelBlue{96, 128, 255, 255};
 constexpr SDL_Color PastelYellow{255, 224, 128, 255};
 constexpr SDL_Color PastelRed{255, 96, 96, 255};
 constexpr SDL_Color PastelGray{176, 176, 176, 255};
+constexpr SDL_Color PastelPurple{192, 160, 255, 255};
 } // namespace MenuColors
 
 // Represents an interactive button in a menu

--- a/inc/MainMenu.hpp
+++ b/inc/MainMenu.hpp
@@ -3,6 +3,14 @@
 
 // Main menu displayed before starting the game
 class MainMenu : public AMenu {
+protected:
+    int button_rows() const override;
+    void adjust_button_metrics(float scale_factor, int &button_width, int &button_height,
+                               int &button_gap) const override;
+    void layout_buttons(std::vector<Button> &buttons, int width, int height,
+                        float scale_factor, int button_width, int button_height,
+                        int button_gap, int start_y, int center_x) override;
+
 public:
     MainMenu();
     static bool show(int width, int height);

--- a/inc/PauseMenu.hpp
+++ b/inc/PauseMenu.hpp
@@ -6,6 +6,14 @@ struct SDL_Renderer;
 
 // Menu shown when the game is paused
 class PauseMenu : public AMenu {
+protected:
+    int button_rows() const override;
+    void adjust_button_metrics(float scale_factor, int &button_width, int &button_height,
+                               int &button_gap) const override;
+    void layout_buttons(std::vector<Button> &buttons, int width, int height,
+                        float scale_factor, int button_width, int button_height,
+                        int button_gap, int start_y, int center_x) override;
+
 public:
     PauseMenu();
     static bool show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -1,14 +1,63 @@
 #include "MainMenu.hpp"
 #include <SDL.h>
+#include <algorithm>
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
     buttons.push_back(Button{"PLAY", ButtonAction::Play, MenuColors::PastelGreen});
     buttons.push_back(
+        Button{"TUTORIAL", ButtonAction::Tutorial, MenuColors::PastelPurple});
+    buttons.push_back(
+        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelYellow});
+    buttons.push_back(
         Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
-    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
+    buttons.push_back(
+        Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelGray});
     buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
-    corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
+}
+
+int MainMenu::button_rows() const {
+    if (buttons.empty())
+        return 0;
+    return static_cast<int>((buttons.size() + 1) / 2);
+}
+
+void MainMenu::adjust_button_metrics(float, int &button_width, int &button_height,
+                                     int &button_gap) const {
+    button_width = static_cast<int>(button_width * 0.9f);
+    button_height = static_cast<int>(button_height * 0.85f);
+    button_gap = static_cast<int>(button_gap * 0.6f);
+}
+
+void MainMenu::layout_buttons(std::vector<Button> &buttons_list, int width, int height,
+                              float scale_factor, int button_width, int button_height,
+                              int button_gap, int start_y, int center_x) {
+    (void)height;
+    (void)scale_factor;
+    (void)center_x;
+    if (buttons_list.size() < 2) {
+        AMenu::layout_buttons(buttons_list, width, height, scale_factor, button_width,
+                              button_height, button_gap, start_y, center_x);
+        return;
+    }
+
+    int left_column_width = button_width;
+    int right_column_width = button_width;
+    int vertical_gap = std::max(1, button_gap);
+    int column_gap = std::max(vertical_gap, left_column_width / 12);
+    auto adjust_rect = [&](std::size_t index, SDL_Rect &rect) {
+        if (index < buttons_list.size() &&
+            buttons_list[index].action == ButtonAction::Tutorial) {
+            int tutorial_width = static_cast<int>(left_column_width * 0.75f);
+            if (tutorial_width < 1)
+                tutorial_width = 1;
+            rect.x += (rect.w - tutorial_width) / 2;
+            rect.w = tutorial_width;
+        }
+    };
+
+    layout_two_column_grid(buttons_list, width, button_height, vertical_gap, start_y,
+                           left_column_width, right_column_width, column_gap,
+                           adjust_rect);
 }
 
 bool MainMenu::show(int width, int height) {

--- a/src/PauseMenu.cpp
+++ b/src/PauseMenu.cpp
@@ -1,14 +1,48 @@
 #include "PauseMenu.hpp"
+#include <algorithm>
 
 PauseMenu::PauseMenu() : AMenu("PAUSE") {
     title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
     buttons.push_back(Button{"RESUME", ButtonAction::Resume, MenuColors::PastelGreen});
     buttons.push_back(
+        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelYellow});
+    buttons.push_back(
         Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
-    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
+    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelGray});
     buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
-    corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
+}
+
+int PauseMenu::button_rows() const {
+    if (buttons.empty())
+        return 0;
+    return static_cast<int>((buttons.size() + 1) / 2);
+}
+
+void PauseMenu::adjust_button_metrics(float, int &button_width, int &button_height,
+                                      int &button_gap) const {
+    button_width = static_cast<int>(button_width * 0.9f);
+    button_height = static_cast<int>(button_height * 0.85f);
+    button_gap = static_cast<int>(button_gap * 0.6f);
+}
+
+void PauseMenu::layout_buttons(std::vector<Button> &buttons_list, int width, int height,
+                               float scale_factor, int button_width, int button_height,
+                               int button_gap, int start_y, int center_x) {
+    (void)height;
+    (void)scale_factor;
+    (void)center_x;
+    if (buttons_list.size() < 2) {
+        AMenu::layout_buttons(buttons_list, width, height, scale_factor, button_width,
+                              button_height, button_gap, start_y, center_x);
+        return;
+    }
+
+    int left_column_width = button_width;
+    int right_column_width = button_width;
+    int vertical_gap = std::max(1, button_gap);
+    int column_gap = std::max(vertical_gap, left_column_width / 12);
+    layout_two_column_grid(buttons_list, width, button_height, vertical_gap, start_y,
+                           left_column_width, right_column_width, column_gap);
 }
 
 bool PauseMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {


### PR DESCRIPTION
## Summary
- shrink the menu button metrics and add a reusable two-column grid helper for tighter spacing
- swap the HOW TO PLAY and SETTINGS hover colors while keeping the tutorial button at three-quarters width on the main menu
- move the pause menu onto the same two-column grid so its buttons mirror the main menu layout

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b05ba0f0832f9ac0cf3fd6616148