### PR TITLE
Add tutorial mode scene selection

### DIFF
--- a/inc/Application.hpp
+++ b/inc/Application.hpp
@@ -11,4 +11,4 @@
  * @param quality Render quality (L/M/H).
  */
 void run_application(const std::string &scene_path, int width, int height,
-					 char quality);
+                                         char quality, bool tutorial_mode);

--- a/inc/MainMenu.hpp
+++ b/inc/MainMenu.hpp
@@ -13,5 +13,5 @@ protected:
 
 public:
     MainMenu();
-    static bool show(int width, int height);
+    static ButtonAction show(int width, int height);
 };

--- a/inc/Renderer.hpp
+++ b/inc/Renderer.hpp
@@ -25,7 +25,7 @@ class Renderer
         void render_ppm(const std::string &path, const std::vector<Material> &mats,
                                         const RenderSettings &rset);
         void render_window(std::vector<Material> &mats, const RenderSettings &rset,
-                                           const std::string &scene_path);
+                                           const std::string &scene_path, bool tutorial_mode);
         private:
         struct RenderState;
         void mark_scene_dirty(RenderState &st);

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -158,7 +158,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                         present_background();
                         HowToPlayMenu::show(window, renderer, width, height, transparent);
                     } else if (btn.action == ButtonAction::Tutorial) {
-                        // Tutorial button is a placeholder and does not trigger an action yet.
+                        result = btn.action;
+                        running = false;
                     } else {
                         result = btn.action;
                         running = false;

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -8,7 +8,7 @@
 
 // Launch the rendering pipeline and display the interactive window.
 void run_application(const std::string &scene_path, int width, int height,
-					 char quality)
+                                         char quality, bool tutorial_mode)
 {
 	unsigned int thread_count;
 	thread_count = std::thread::hardware_concurrency();
@@ -47,5 +47,5 @@ void run_application(const std::string &scene_path, int width, int height,
 	render_settings.threads = thread_count;
 	render_settings.downscale = downscale;
 	Renderer renderer(scene, camera);
-	renderer.render_window(materials, render_settings, scene_path);
+        renderer.render_window(materials, render_settings, scene_path, tutorial_mode);
 }

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -82,26 +82,26 @@ void MainMenu::layout_buttons(std::vector<Button> &buttons_list, int width, int 
     }
 }
 
-bool MainMenu::show(int width, int height) {
+ButtonAction MainMenu::show(int width, int height) {
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-        return false;
+        return ButtonAction::Quit;
     }
     SDL_Window *window = SDL_CreateWindow("MiniRT", SDL_WINDOWPOS_CENTERED,
                                           SDL_WINDOWPOS_CENTERED, width, height, 0);
     if (!window) {
         SDL_Quit();
-        return false;
+        return ButtonAction::Quit;
     }
     SDL_Renderer *renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
     if (!renderer) {
         SDL_DestroyWindow(window);
         SDL_Quit();
-        return false;
+        return ButtonAction::Quit;
     }
     MainMenu menu;
     ButtonAction action = menu.run(window, renderer, width, height);
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return action == ButtonAction::Play;
+    return action;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,84 @@
 #include "CommandLine.hpp"
 #include "MainMenu.hpp"
 #include "Settings.hpp"
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <iostream>
+#include <iterator>
+#include <optional>
 #include <string>
+#include <vector>
+
+namespace
+{
+
+std::optional<std::string> find_first_tutorial_scene()
+{
+        namespace fs = std::filesystem;
+        const std::string prefix = "tutorial_";
+        fs::path scenes_dir = "scenes";
+        std::error_code ec;
+        if (!fs::exists(scenes_dir, ec) || !fs::is_directory(scenes_dir, ec))
+                return std::nullopt;
+        std::vector<fs::path> tutorials;
+        for (auto &entry : fs::directory_iterator(scenes_dir, ec))
+        {
+                if (ec)
+                        break;
+                if (!entry.is_regular_file(ec))
+                        continue;
+                fs::path path = entry.path();
+                std::string ext = path.extension().string();
+                std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) {
+                        return static_cast<char>(std::tolower(ch));
+                });
+                if (ext != ".toml")
+                        continue;
+                std::string stem = path.stem().string();
+                std::string lowered;
+                lowered.reserve(stem.size());
+                std::transform(stem.begin(), stem.end(), std::back_inserter(lowered),
+                               [](unsigned char ch) {
+                                       return static_cast<char>(std::tolower(ch));
+                               });
+                if (lowered.rfind(prefix, 0) != 0 || lowered.size() <= prefix.size())
+                        continue;
+                bool numeric_suffix = true;
+                for (std::size_t i = prefix.size(); i < lowered.size(); ++i)
+                {
+                        if (!std::isdigit(static_cast<unsigned char>(lowered[i])))
+                        {
+                                numeric_suffix = false;
+                                break;
+                        }
+                }
+                if (!numeric_suffix)
+                        continue;
+                tutorials.push_back(path);
+        }
+        if (tutorials.empty())
+                return std::nullopt;
+        auto suffix_value = [&](const fs::path &p) {
+                std::string stem = p.stem().string();
+                int value = 0;
+                for (std::size_t i = prefix.size(); i < stem.size(); ++i)
+                {
+                        value = value * 10 + (stem[i] - '0');
+                }
+                return value;
+        };
+        std::sort(tutorials.begin(), tutorials.end(), [&](const fs::path &a, const fs::path &b) {
+                int value_a = suffix_value(a);
+                int value_b = suffix_value(b);
+                if (value_a != value_b)
+                        return value_a < value_b;
+                return a.string() < b.string();
+        });
+        return tutorials.front().string();
+}
+
+} // namespace
 
 /**
  * Program entry point.
@@ -17,11 +94,23 @@ int main(int argc, char **argv)
         load_settings();
         int width = g_settings.width;
         int height = g_settings.height;
-        bool play = MainMenu::show(width, height);
-        if (!play)
+        ButtonAction action = MainMenu::show(width, height);
+        if (action != ButtonAction::Play && action != ButtonAction::Tutorial)
         {
                 return 0;
         }
-        run_application(scene_path, g_settings.width, g_settings.height, g_settings.quality);
+        bool tutorial_mode = (action == ButtonAction::Tutorial);
+        if (tutorial_mode)
+        {
+                auto tutorial_scene = find_first_tutorial_scene();
+                if (!tutorial_scene)
+                {
+                        std::cerr << "No tutorial maps available.\n";
+                        return 1;
+                }
+                scene_path = *tutorial_scene;
+        }
+        run_application(scene_path, g_settings.width, g_settings.height, g_settings.quality,
+                                        tutorial_mode);
         return 0;
 }


### PR DESCRIPTION
## Summary
- allow the tutorial button to exit the main menu by returning the selected action
- detect available tutorial scene files and start tutorial mode from the first matching tutorial_x map
- propagate the tutorial mode flag into the renderer so only tutorial_x maps are considered for progression
- display a tutorial-only instruction bar at the bottom HUD with placeholder guidance text

## Testing
- cmake -S . -B build *(fails: SDL2 development files are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3dd70e7e0832fbaeeed562191ac05