### PR TITLE
Add CLI scene path argument to skip main menu

### DIFF
--- a/inc/CommandLine.hpp
+++ b/inc/CommandLine.hpp
@@ -3,11 +3,12 @@
 #include <string>
 
 /**
- * Prepares the default scene path.
+ * Parses command line arguments and determines the starting scene.
  *
- * @param argc Argument count (unused).
- * @param argv Argument values (unused).
+ * @param argc Argument count.
+ * @param argv Argument values.
  * @param scene_path Output path to scene file.
+ * @param skip_main_menu Set to true when a scene is provided on the command line.
  * @return True on success.
  */
-bool parse_arguments(int argc, char **argv, std::string &scene_path);
+bool parse_arguments(int argc, char **argv, std::string &scene_path, bool &skip_main_menu);

--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -1,9 +1,64 @@
 #include "CommandLine.hpp"
 
-bool parse_arguments(int argc, char **argv, std::string &scene_path)
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <iostream>
+
+namespace
 {
-    (void)argc;
-    (void)argv;
+
+std::string to_lower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+} // namespace
+
+bool parse_arguments(int argc, char **argv, std::string &scene_path, bool &skip_main_menu)
+{
+    namespace fs = std::filesystem;
+
     scene_path = "scenes/level_1.toml";
+    skip_main_menu = false;
+
+    if (argc <= 1)
+    {
+        return true;
+    }
+
+    if (argc > 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " [path/to/scene.toml]\n";
+        return false;
+    }
+
+    std::string provided_path = argv[1];
+    if (provided_path.empty())
+    {
+        std::cerr << "Error: Scene path cannot be empty.\n";
+        return false;
+    }
+
+    fs::path scene_file(provided_path);
+    std::string extension = to_lower(scene_file.extension().string());
+    if (extension != ".toml")
+    {
+        std::cerr << "Error: Scene file must have a .toml extension.\n";
+        return false;
+    }
+
+    std::error_code ec;
+    if (!fs::exists(scene_file, ec) || !fs::is_regular_file(scene_file, ec))
+    {
+        std::cerr << "Error: Scene file '" << provided_path << "' was not found.\n";
+        return false;
+    }
+
+    scene_path = scene_file.string();
+    skip_main_menu = true;
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,11 +87,21 @@ std::optional<std::string> find_first_tutorial_scene()
 int main(int argc, char **argv)
 {
         std::string default_scene_path;
-        if (!parse_arguments(argc, argv, default_scene_path))
+        bool skip_main_menu = false;
+        if (!parse_arguments(argc, argv, default_scene_path, skip_main_menu))
         {
                 return 1;
         }
         load_settings();
+
+        if (skip_main_menu)
+        {
+                run_application(default_scene_path, g_settings.width, g_settings.height,
+                                g_settings.quality, false);
+                load_settings();
+                return 0;
+        }
+
         bool keep_running = true;
         while (keep_running)
         {


### PR DESCRIPTION
## Summary
- parse an optional command-line argument that points to a scene TOML file
- validate the provided scene path and flag that the main menu should be skipped
- launch the game directly into the requested scene when supplied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d667858bac832fb130f0e85982f561