### PR TITLE
Update object descriptions in how to play instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Earn points by illuminating object surfaces; the total score must reach each lev
 -------------------------------------------------------------------
 Object rules:
 - <span style="color: #008000;">Green</span> objects can both move and rotate.
-- <span style="color: #FFD700;">Yellow</span> objects rotate but can’t move.
+- <span style="color: #FFD700;">Yellow</span> objects can be rotated but can’t be moved.
 - <span style="color: #FF0000;">Red</span> objects stay put – you can’t move or rotate them.
-- <span style="color: #808080;">Grey</span> objects just block the beam; they don’t score points.
+- <span style="color: #808080;">Grey</span> objects are obstacles – they don’t score points and can’t be moved or rotated.
 
 <div align="center">Aim at any object to display information about it.</div>
 

--- a/src/HowToPlayMenu.cpp
+++ b/src/HowToPlayMenu.cpp
@@ -167,7 +167,8 @@ void HowToPlayMenu::draw_content(SDL_Renderer *renderer, int width, int height, 
         yellow_rule.gap_before = bullet_gap;
         yellow_rule.custom_height = -1;
         yellow_rule.alignment = ParagraphAlign::Left;
-        yellow_rule.segments = {{"Yellow", yellow, false}, {" objects rotate but can't move.", white, false}};
+        yellow_rule.segments = {{"Yellow", yellow, false},
+                                {" objects can be rotated but can't be moved.", white, false}};
         paragraphs.push_back(std::move(yellow_rule));
 
         Paragraph red_rule{};
@@ -187,7 +188,8 @@ void HowToPlayMenu::draw_content(SDL_Renderer *renderer, int width, int height, 
         grey_rule.custom_height = -1;
         grey_rule.alignment = ParagraphAlign::Left;
         grey_rule.segments = {{"Grey", grey, false},
-                              {" objects just block the beam; they don't score points.", white, false}};
+                              {" objects are obstacles - they don't score points and can't be moved or rotated.", white,
+                               false}};
         paragraphs.push_back(std::move(grey_rule));
 
         Paragraph aim_tip{};


### PR DESCRIPTION
## Summary
- clarify yellow object behavior in the How to Play menu
- describe grey objects as immovable obstacles in the How to Play menu and README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d66e7c3434832f9492864a3aadebad