### PR TITLE
Add tutorial prompt parsing and HUD support

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -4,6 +4,7 @@
 #include "light.hpp"
 #include "material.hpp"
 #include <memory>
+#include <string>
 #include <vector>
 #include <unordered_map>
 
@@ -19,6 +20,7 @@ class Scene
         std::shared_ptr<Hittable> accel;
         bool target_required = false;
         double minimal_score = 0.0;
+        std::vector<std::string> tutorial_prompts;
 
         // Update beam objects and associated lights in the scene.
         void update_beams(const std::vector<Material> &materials);


### PR DESCRIPTION
## Summary
- add scene support for tutorial prompts and parse [prompts] sections in tutorial maps
- ensure tutorial files replace quota validation with prompt requirements while keeping stage ordering intact
- display tutorial prompts in the HUD, advance them with ENTER, and gate level completion on finishing the prompts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6752a4bf8832f98fc373b0d7c9948