### PR TITLE
Refine tutorial HUD prompt display

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
+#include <string>
 
 class Camera;
 class Laser;
@@ -19,6 +20,7 @@ class Scene
         std::shared_ptr<Hittable> accel;
         bool target_required = false;
         double minimal_score = 0.0;
+        std::vector<std::string> prompts;
 
         // Update beam objects and associated lights in the scene.
         void update_beams(const std::vector<Material> &materials);


### PR DESCRIPTION
## Summary
- wrap tutorial prompt text to the HUD width so it stays centered and fits within the bottom bar
- remove tutorial-mode control hints so the bottom HUD only shows prompt strings

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package)*

------
https://chatgpt.com/codex/tasks/task_e_68d6752a4bf8832f98fc373b0d7c9948