### PR TITLE
Polish tutorial HUD continue cues

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -908,6 +908,7 @@ struct Renderer::RenderState
         std::string scene_path;
         std::vector<std::filesystem::path> level_paths;
         int current_level_index = 0;
+        int total_levels = 0;
         double cumulative_score = 0.0;
         std::string player_name;
         int hud_focus_object = -1;
@@ -1845,13 +1846,27 @@ int Renderer::render_hud(const RenderState &st, SDL_Renderer *ren, int W, int H)
         const int hud_padding = 12;
 
         std::vector<HudTextLine> left_lines;
-        std::string level_line;
-        if (st.level_number > 0)
-                level_line = "LEVEL " + std::to_string(st.level_number);
+        int level_id = st.level_number;
+        if (level_id <= 0 && st.current_level_index >= 0)
+                level_id = st.current_level_index + 1;
+
+        std::string level_display;
+        if (level_id > 0)
+                level_display = std::to_string(level_id);
         else if (!st.level_label.empty())
-                level_line = "LEVEL " + st.level_label;
+                level_display = st.level_label;
         else
-                level_line = "LEVEL ?";
+                level_display = "?";
+
+        std::string total_display;
+        if (st.total_levels > 0)
+                total_display = std::to_string(st.total_levels);
+        else if (!st.level_paths.empty())
+                total_display = std::to_string(st.level_paths.size());
+        else
+                total_display = "?";
+
+        std::string level_line = "Level " + level_display + "/" + total_display;
         left_lines.push_back({level_line, SDL_Color{255, 255, 255, 255}});
 
         if (scene.target_required)
@@ -1882,13 +1897,53 @@ int Renderer::render_hud(const RenderState &st, SDL_Renderer *ren, int W, int H)
         }
         left_lines.push_back({score_buf, score_color});
 
+        bool tutorial_has_next_level = false;
+        if (st.tutorial_mode)
+        {
+                int current_index = st.current_level_index;
+                if (current_index < 0)
+                {
+                        auto current_path = std::filesystem::path(st.scene_path);
+                        current_index = level_index_for(st.level_paths, current_path);
+                }
+                for (int i = current_index + 1;
+                     i < static_cast<int>(st.level_paths.size()); ++i)
+                {
+                        if (path_is_level_for_mode(st.level_paths[i], st.tutorial_mode))
+                        {
+                                tutorial_has_next_level = true;
+                                break;
+                        }
+                }
+        }
+
         std::vector<HudTextLine> center_lines;
         if (st.quota_met)
         {
-                center_lines.push_back(
-                        {"LEVEL FINISHED", SDL_Color{255, 255, 255, 255}});
-                center_lines.push_back(
-                        {"ENTER TO CONTINUE", SDL_Color{255, 255, 255, 255}});
+                if (st.tutorial_mode)
+                {
+                        if (tutorial_has_next_level)
+                        {
+                                center_lines.push_back(
+                                        {"LEVEL FINISHED", SDL_Color{255, 255, 255, 255}});
+                                center_lines.push_back(
+                                        {"ENTER to continue", SDL_Color{255, 255, 255, 255}});
+                        }
+                        else
+                        {
+                                center_lines.push_back(
+                                        {"TUTORIAL FINISHED.", SDL_Color{255, 255, 255, 255}});
+                                center_lines.push_back(
+                                        {"ENTER to continue", SDL_Color{255, 255, 255, 255}});
+                        }
+                }
+                else
+                {
+                        center_lines.push_back(
+                                {"LEVEL FINISHED", SDL_Color{255, 255, 255, 255}});
+                        center_lines.push_back(
+                                {"ENTER TO CONTINUE", SDL_Color{255, 255, 255, 255}});
+                }
         }
 
         std::vector<HudTextLine> right_lines;
@@ -2261,10 +2316,20 @@ int Renderer::render_hud(const RenderState &st, SDL_Renderer *ren, int W, int H)
         bool tutorial_continue_ready =
                 st.tutorial_mode &&
                 (hud_ticks - st.tutorial_prompt_shown_at >= kTutorialContinueDelayMs);
-        bool show_tutorial_continue_hint = tutorial_has_next_prompt && tutorial_continue_ready;
-        if (!st.quota_met && show_tutorial_continue_hint)
+        bool show_tutorial_continue_hint = st.tutorial_mode && !st.quota_met &&
+                                           !st.tutorial_prompts.empty() &&
+                                           tutorial_continue_ready;
+        if (show_tutorial_continue_hint)
         {
-                center_lines.push_back({"ENTER to continue", neutral, true});
+                if (!tutorial_has_next_prompt && !tutorial_has_next_level)
+                {
+                        center_lines.push_back({"TUTORIAL FINISHED.", neutral, true});
+                        center_lines.push_back({"ENTER to continue", neutral, true});
+                }
+                else
+                {
+                        center_lines.push_back({"ENTER to continue", neutral, true});
+                }
         }
         int wrap_margin = hud_padding + std::max(2, hud_padding / 2);
         int wrap_width = std::max(1, W - 2 * wrap_margin);
@@ -2381,7 +2446,26 @@ int Renderer::render_hud(const RenderState &st, SDL_Renderer *ren, int W, int H)
 
         if (!center_lines.empty())
         {
+                bool all_blinking = std::all_of(center_lines.begin(), center_lines.end(),
+                                                [](const HudTextLine &line) {
+                                                        return line.blink;
+                                                });
                 int center_y = hud_padding;
+                if (all_blinking)
+                {
+                        int visible_lines = 0;
+                        for (const auto &line : center_lines)
+                        {
+                                if (!line.blink || blink_on)
+                                        ++visible_lines;
+                        }
+                        if (visible_lines == 0)
+                                visible_lines = static_cast<int>(center_lines.size());
+                        int available_height = std::max(0, top_bar_height - 2 * hud_padding);
+                        int content_height = visible_lines * hud_line_height;
+                        if (available_height > content_height)
+                                center_y = hud_padding + (available_height - content_height) / 2;
+                }
                 for (const auto &line : center_lines)
                 {
                         if (line.blink && !blink_on)
@@ -2845,6 +2929,7 @@ bool Renderer::render_window(std::vector<Material> &mats,
         st.scene_path = absolute_scene_path.string();
         st.tutorial_mode = tutorial_mode;
         st.level_paths = collect_level_paths(absolute_scene_path, st.tutorial_mode);
+        st.total_levels = static_cast<int>(st.level_paths.size());
         st.current_level_index = level_index_for(st.level_paths, absolute_scene_path);
         st.cumulative_score = 0.0;
         st.player_name.clear();


### PR DESCRIPTION
## Summary
- adjust the tutorial HUD to reuse upcoming-level information and show "ENTER to continue" while more content remains
- surface a "TUTORIAL FINISHED." message for the final tutorial prompt/level and center blinking prompts within the HUD highlight

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83ba3cef4832fb06de0dbfbc413d9