### PR TITLE
Center tutorial prompts in split HUD

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
+#include <string>
 
 class Camera;
 class Laser;
@@ -19,6 +20,7 @@ class Scene
         std::shared_ptr<Hittable> accel;
         bool target_required = false;
         double minimal_score = 0.0;
+        std::vector<std::string> prompts;
 
         // Update beam objects and associated lights in the scene.
         void update_beams(const std::vector<Material> &materials);


### PR DESCRIPTION
## Summary
- shorten the tutorial prompt continue delay to two seconds and keep the active prompt text handy for HUD rendering
- wrap and center tutorial prompts within an 85/15 split bottom bar that reserves room for the continue hint only after it becomes visible
- draw the "Press `ENTER` to continue" cue inside the bottom HUD section instead of the top bar once the delay elapses

## Testing
- cmake -S . -B build *(fails: missing SDL2 development files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6752a4bf8832f98fc373b0d7c9948