### PR TITLE
Adjust tutorial completion menu

### DIFF
--- a/inc/LevelFinishedMenu.hpp
+++ b/inc/LevelFinishedMenu.hpp
@@ -10,6 +10,7 @@ struct LevelFinishedStats {
     double required_score = 0.0;
     double total_score = 0.0;
     bool has_next_level = false;
+    bool tutorial_mode = false;
 };
 
 class LevelFinishedMenu : public AMenu {

--- a/src/LevelFinishedMenu.cpp
+++ b/src/LevelFinishedMenu.cpp
@@ -105,6 +105,8 @@ std::string ordinal(int value) {
 }
 
 std::string make_title(const LevelFinishedStats &stats) {
+    if (stats.tutorial_mode)
+        return "TUTORIAL FINISHED";
     std::ostringstream oss;
     oss << "LEVEL " << std::max(0, stats.completed_levels) << "/"
         << std::max(0, stats.total_levels) << " FINISHED";
@@ -153,6 +155,89 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
             SDL_FreeSurface(surface);
         }
         SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+    }
+
+    if (stats_.tutorial_mode) {
+        Button back_button{"BACK TO MENU", ButtonAction::BackToMenu,
+                           SDL_Color{192, 160, 255, 255}};
+        while (running) {
+            SDL_GetWindowSize(window, &width, &height);
+            float scale_factor = static_cast<float>(height) / 600.0f;
+            int base_scale = std::max(1, static_cast<int>(4 * scale_factor));
+            int title_scale = base_scale * 2;
+            int button_width = std::max(180, static_cast<int>(320 * scale_factor));
+            int button_height = std::max(60, static_cast<int>(90 * scale_factor));
+            int margin = std::max(10, static_cast<int>(60 * scale_factor));
+
+            int title_x = width / 2 - CustomCharacter::text_width(title, title_scale) / 2;
+            int title_y = margin;
+            back_button.rect = {width / 2 - button_width / 2,
+                                height - button_height - margin, button_width, button_height};
+
+            SDL_Event event;
+            while (SDL_PollEvent(&event)) {
+                if (event.type == SDL_QUIT) {
+                    running = false;
+                    result = ButtonAction::Quit;
+                } else if (event.type == SDL_KEYDOWN &&
+                           (event.key.keysym.scancode == SDL_SCANCODE_RETURN ||
+                            event.key.keysym.scancode == SDL_SCANCODE_KP_ENTER ||
+                            event.key.keysym.scancode == SDL_SCANCODE_ESCAPE)) {
+                    running = false;
+                    result = ButtonAction::BackToMenu;
+                } else if (event.type == SDL_MOUSEBUTTONDOWN &&
+                           event.button.button == SDL_BUTTON_LEFT) {
+                    int mx = event.button.x;
+                    int my = event.button.y;
+                    if (point_in_rect(back_button.rect, mx, my)) {
+                        running = false;
+                        result = ButtonAction::BackToMenu;
+                    }
+                }
+            }
+
+            int mx, my;
+            SDL_GetMouseState(&mx, &my);
+
+            if (transparent && background) {
+                SDL_RenderCopy(renderer, background, nullptr, nullptr);
+                SDL_SetRenderDrawColor(renderer, 0, 0, 0, 153);
+                SDL_Rect overlay{0, 0, width, height};
+                SDL_RenderFillRect(renderer, &overlay);
+            } else {
+                SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+                SDL_RenderClear(renderer);
+            }
+
+            int tx = title_x;
+            for (std::size_t i = 0; i < title.size(); ++i) {
+                SDL_Color c = i < title_colors.size() ? title_colors[i] : white;
+                CustomCharacter::draw_character(renderer, title[i], tx, title_y, c, title_scale);
+                tx += (5 + 1) * title_scale;
+            }
+
+            auto draw_button = [&](const Button &btn) {
+                bool hover = point_in_rect(btn.rect, mx, my);
+                SDL_Color fill = hover ? btn.hover_color : SDL_Color{96, 96, 160, 220};
+                SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+                SDL_RenderFillRect(renderer, &btn.rect);
+                SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+                SDL_RenderDrawRect(renderer, &btn.rect);
+                int text_scale = base_scale;
+                int text_width = CustomCharacter::text_width(btn.text, text_scale);
+                int text_x = btn.rect.x + (btn.rect.w - text_width) / 2;
+                int text_y = btn.rect.y + (btn.rect.h - 7 * text_scale) / 2;
+                CustomCharacter::draw_text(renderer, btn.text, text_x, text_y, white, text_scale);
+            };
+
+            draw_button(back_button);
+            SDL_RenderPresent(renderer);
+            SDL_Delay(16);
+        }
+
+        if (background)
+            SDL_DestroyTexture(background);
+        return result;
     }
 
     const bool show_name_input = !stats_.has_next_level;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1074,11 +1074,17 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                 stats.required_score = scene.minimal_score;
                 stats.total_score = st.cumulative_score + st.last_score;
                 stats.has_next_level = next_level_index(st).has_value();
+                stats.tutorial_mode = st.tutorial_mode;
                 ButtonAction action = LevelFinishedMenu::show(
                         win, ren, current_w, current_h, stats, st.player_name, true);
                 if (action == ButtonAction::Quit)
                 {
                         st.running = false;
+                }
+                else if (action == ButtonAction::BackToMenu)
+                {
+                        st.running = false;
+                        st.return_to_menu = true;
                 }
                 else if (action == ButtonAction::NextLevel)
                 {


### PR DESCRIPTION
## Summary
- add a tutorial mode flag to level completion stats
- render a simplified "Tutorial Finished" menu with only a back-to-menu button
- route the tutorial completion action back to the main menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8bbb3a54832fa8017745feab9c45