### PR TITLE
Preserve progress when returning to menu

### DIFF
--- a/inc/Application.hpp
+++ b/inc/Application.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "GameSession.hpp"
 #include <string>
 
 /**
@@ -11,4 +12,5 @@
  * @param quality Render quality (L/M/H).
  */
 bool run_application(const std::string &scene_path, int width, int height,
-                                        char quality, bool tutorial_mode);
+                                        char quality, bool tutorial_mode,
+                                        GameSession *session);

--- a/inc/GameSession.hpp
+++ b/inc/GameSession.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+struct GameSession {
+    bool has_progress = false;
+    bool tutorial_mode = false;
+    std::string next_scene_path;
+    double cumulative_score = 0.0;
+    int completed_levels = 0;
+    std::string player_name;
+};
+

--- a/inc/Renderer.hpp
+++ b/inc/Renderer.hpp
@@ -8,6 +8,7 @@
 struct SDL_Window;
 struct SDL_Renderer;
 struct SDL_Texture;
+struct GameSession;
 
 class RenderSettings
 {
@@ -25,14 +26,16 @@ class Renderer
         void render_ppm(const std::string &path, const std::vector<Material> &mats,
                                         const RenderSettings &rset);
         bool render_window(std::vector<Material> &mats, const RenderSettings &rset,
-                                           const std::string &scene_path, bool tutorial_mode);
+                                           const std::string &scene_path, bool tutorial_mode,
+                                           GameSession *session);
 		struct RenderState;
         private:
         void mark_scene_dirty(RenderState &st);
         bool init_sdl(SDL_Window *&win, SDL_Renderer *&ren, SDL_Texture *&tex,
                                        int W, int H, int RW, int RH);
         void process_events(RenderState &st, SDL_Window *win, SDL_Renderer *ren,
-                                               int W, int H, std::vector<Material> &mats);
+                                               int W, int H, std::vector<Material> &mats,
+                                               GameSession *session);
         void handle_keyboard(RenderState &st, double dt,
                                                std::vector<Material> &mats);
         void update_selection(RenderState &st, std::vector<Material> &mats);

--- a/src/LevelFinishedMenu.cpp
+++ b/src/LevelFinishedMenu.cpp
@@ -253,7 +253,8 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
     Button next_button{"NEXT LEVEL", ButtonAction::NextLevel, SDL_Color{96, 255, 128, 255}};
     Button leaderboard_button{"LEADERBOARD", ButtonAction::Leaderboard,
                               SDL_Color{96, 128, 255, 255}};
-    Button quit_button{"QUIT", ButtonAction::Quit, SDL_Color{255, 96, 96, 255}};
+    Button menu_button{"BACK TO MENU", ButtonAction::BackToMenu,
+                       SDL_Color{255, 96, 96, 255}};
     SDL_Color submit_idle_color{64, 160, 96, 220};
     Button submit_button{"SUBMIT", ButtonAction::None, SDL_Color{96, 255, 128, 255}};
 
@@ -299,7 +300,7 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
         int bottom_total_width = button_width * 2 + button_gap;
         int bottom_start_x = width / 2 - bottom_total_width / 2;
         leaderboard_button.rect = {bottom_start_x, bottom_y, button_width, button_height};
-        quit_button.rect = {bottom_start_x + button_width + button_gap, bottom_y, button_width,
+        menu_button.rect = {bottom_start_x + button_width + button_gap, bottom_y, button_width,
                             button_height};
 
         SDL_Rect name_rect{0, 0, 0, 0};
@@ -396,9 +397,9 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
                     LeaderboardMenu::show(window, renderer, width, height, transparent);
                     if (was_active && allow_name_input)
                         SDL_StartTextInput();
-                } else if (point_in_rect(quit_button.rect, mx, my)) {
+                } else if (point_in_rect(menu_button.rect, mx, my)) {
                     running = false;
-                    result = ButtonAction::Quit;
+                    result = ButtonAction::BackToMenu;
                 } else if (allow_name_input && point_in_rect(name_rect, mx, my)) {
                     name_field_active = true;
                     if (!SDL_IsTextInputActive())
@@ -522,7 +523,7 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
         if (stats_.has_next_level)
             draw_button(next_button, true, false, SDL_Color{}, false);
         draw_button(leaderboard_button, true, false, SDL_Color{}, false);
-        draw_button(quit_button, true, false, SDL_Color{}, false);
+        draw_button(menu_button, true, false, SDL_Color{}, false);
 
         if (show_name_input) {
             SDL_Color bg_color{20, 20, 20, 220};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "Application.hpp"
+#include "GameSession.hpp"
 #include "CommandLine.hpp"
 #include "MainMenu.hpp"
 #include "Settings.hpp"
@@ -94,10 +95,12 @@ int main(int argc, char **argv)
         }
         load_settings();
 
+        GameSession session_state;
+
         if (skip_main_menu)
         {
                 run_application(default_scene_path, g_settings.width, g_settings.height,
-                                g_settings.quality, false);
+                                g_settings.quality, false, nullptr);
                 load_settings();
                 return 0;
         }
@@ -132,7 +135,8 @@ int main(int argc, char **argv)
                 bool back_to_menu = run_application(scene_path, g_settings.width,
                                                                                 g_settings.height,
                                                                                 g_settings.quality,
-                                                                                tutorial_mode);
+                                                                                tutorial_mode,
+                                                                                &session_state);
                 load_settings();
                 if (!back_to_menu)
                 {


### PR DESCRIPTION
## Summary
- add a GameSession struct and thread it through the application loop so returning to the menu keeps the player name, score, and level index
- update the renderer to persist progress when leaving from the pause or level-finished menus and to resume from that state on the next launch
- rename the level-finished "QUIT" button to "BACK TO MENU" so it matches the new behavior

## Testing
- cmake -S . -B build *(fails: missing SDL2 configuration in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dae5e7b36c832fa00c8a874a417cef