### PR TITLE
Respect forced scene while keeping main menu

### DIFF
--- a/inc/CommandLine.hpp
+++ b/inc/CommandLine.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 /**
@@ -12,3 +13,13 @@
  * @return True on success.
  */
 bool parse_arguments(int argc, char **argv, std::string &scene_path, bool &skip_main_menu);
+
+/**
+ * Indicates whether a single level was forced via the command line.
+ */
+bool is_forced_single_level_mode();
+
+/**
+ * Returns the scene path that was provided via the command line.
+ */
+const std::filesystem::path &forced_scene_path();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,7 +97,8 @@ int main(int argc, char **argv)
 
         GameSession session_state;
 
-        if (skip_main_menu)
+        bool forced_single_level = is_forced_single_level_mode();
+        if (skip_main_menu && !forced_single_level)
         {
                 run_application(default_scene_path, g_settings.width, g_settings.height,
                                 g_settings.quality, false, nullptr);
@@ -122,7 +123,11 @@ int main(int argc, char **argv)
                 }
                 bool tutorial_mode = (action == ButtonAction::Tutorial);
                 std::string scene_path = default_scene_path;
-                if (tutorial_mode)
+                if (tutorial_mode && forced_single_level)
+                {
+                        tutorial_mode = false;
+                }
+                else if (tutorial_mode)
                 {
                         auto tutorial_scene = find_first_tutorial_scene();
                         if (!tutorial_scene)


### PR DESCRIPTION
## Summary
- keep command-line scene argument from skipping the main menu while tracking forced single-level mode
- expose helpers so the renderer only queues the requested scene when a forced level is active
- guard the tutorial option so the passed scene remains the only playable level during that session

## Testing
- cmake -S . -B build *(fails: missing SDL2 development files in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db80649548832fabd64a2e7ea36a9f